### PR TITLE
Add beets chroma fingerprinting plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,13 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     jq \
     cron \
+    chromaprint-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # beets: audio library manager + tagger
 # spotdl: Spotify-to-local downloader
-RUN pip install --no-cache-dir beets spotdl
+# pyacoustid: Python bindings for Chromaprint/AcoustID (beets chroma plugin)
+RUN pip install --no-cache-dir beets spotdl pyacoustid
 
 # Scripts go on PATH
 COPY scripts/ /usr/local/bin/

--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -23,7 +23,7 @@ paths:
   singleton: $albumartist/$album/$track - $title
   comp: Various Artists/$album/$track - $title
 
-plugins: fromfilename fetchart embedart scrub duplicates
+plugins: chroma fromfilename fetchart embedart scrub duplicates
 
 fetchart:
   auto: yes


### PR DESCRIPTION
Installs chromaprint-tools (provides fpcalc binary) and pyacoustid
(Python bindings) so the beets chroma plugin can identify tracks by
audio fingerprint via AcoustID, improving match accuracy for songs
with poor or missing metadata.

https://claude.ai/code/session_01BHpghmxeBZGg7p41gMyY9C