### PR TITLE
Fix Docker build: use correct Debian package name for chromaprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     jq \
     cron \
-    chromaprint-tools \
+    libchromaprint-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # beets: audio library manager + tagger


### PR DESCRIPTION
chromaprint-tools does not exist in Debian apt repositories; the correct
package name is libchromaprint-tools.

https://claude.ai/code/session_01UUYWcUMpBESFCBVSggbvzv