### PR TITLE
Point compose.yml at ghcr.io image instead of local build

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   pipeline:
-    build: .
+    image: ghcr.io/sometimeskind/music-pipeline:latest
     container_name: music-pipeline
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
CI already publishes ghcr.io/sometimeskind/music-pipeline:latest on every
push to main. Using the pre-built image ensures the host runs the exact
artifact that passed CI health checks, with no local build step required.

https://claude.ai/code/session_015QUiXH8uDsLY31pp9H5YkH