### PR TITLE
Trigger Navidrome library rescan after ingestion

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,11 @@ services:
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
       # Override with e.g. "0 2 * * *" to change sync schedule
       - CRON_SCHEDULE=${CRON_SCHEDULE:-0 3 * * *}
-    # Navidrome rescan: called from host-side `just rescan` recipe after ingest
+      # Optional: trigger Navidrome library rescan after ingestion
+      # NAVIDROME_URL: base URL, e.g. http://navidrome:4533
+      # NAVIDROME_API_KEY: credentials as user:password
+      - NAVIDROME_URL=${NAVIDROME_URL:-}
+      - NAVIDROME_API_KEY=${NAVIDROME_API_KEY:-}
 
 volumes:
   music-data:

--- a/scripts/music-ingest
+++ b/scripts/music-ingest
@@ -27,6 +27,25 @@ audio_files_in() {
     find "$1" -maxdepth "${2:-1}" -type f | grep -Ei "\.(mp3|flac|ogg|opus|m4a|aac|wav|wma|aiff|ape|mpc)$" || true
 }
 
+navidrome_rescan() {
+    [[ -z "${NAVIDROME_URL:-}" || -z "${NAVIDROME_API_KEY:-}" ]] && return 0
+    local user password
+    IFS=: read -r user password <<< "$NAVIDROME_API_KEY"
+    echo "==> Triggering Navidrome library rescan..."
+    local response
+    response=$(curl -sf \
+        "${NAVIDROME_URL}/rest/startScan?u=${user}&p=${password}&v=1.16.1&c=music-pipeline&f=json" \
+        2>&1) || { echo "WARNING: Navidrome rescan request failed" >&2; return 0; }
+    local status
+    status=$(echo "$response" | jq -r '."subsonic-response".status' 2>/dev/null || echo "unknown")
+    if [[ "$status" == "ok" ]]; then
+        echo "    Navidrome rescan triggered successfully."
+    else
+        echo "WARNING: Navidrome rescan returned unexpected status: $status" >&2
+        echo "    Response: $response" >&2
+    fi
+}
+
 # Remove beets source tags for tracks that were removed from a Spotify playlist.
 # Compares the .spotdl snapshot taken before sync to the updated file after sync.
 # Files are never deleted — only the source association is cleared.
@@ -96,3 +115,6 @@ music-import
 echo ""
 echo "==> Refreshing library metadata..."
 beet update 2>&1 || true
+
+echo ""
+navidrome_rescan


### PR DESCRIPTION
If NAVIDROME_URL and NAVIDROME_API_KEY (user:password) are set, music-ingest
calls the Subsonic startScan endpoint at the end of each run. If either var
is absent the step is skipped silently, preserving existing behavior.

https://claude.ai/code/session_01Xj81U8ziJmKdLHSSiVjjXG