### PR TITLE
feat: add justfile with common pipeline recipes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,23 +13,26 @@ Spotify playlists → spotdl sync → /root/Music/inbox/spotdl/<name>/ → beets
 
 ## Common Commands
 
-All commands require 1Password CLI (`op`) to inject Spotify credentials:
+Most commands are wrapped in `just` recipes (see `justfile` in the repo root). Build is the exception — it doesn't need credentials.
 
 ```bash
 # Build the container image
 docker compose build
 
 # Interactive: add a new playlist
-op run --env-file=.env.tpl -- docker compose run --rm -it pipeline music-setup
+just setup
+
+# Provision all playlists from config/playlists.conf (idempotent)
+just provision
 
 # Start the service (cron-based daily ingest)
-op run --env-file=.env.tpl -- docker compose up -d
+just up
 
 # Run a full ingest immediately
-op run --env-file=.env.tpl -- docker compose exec pipeline music-ingest
+just sync
 
 # Follow logs
-docker compose logs -f pipeline
+just logs
 ```
 
 There is no test suite. Shell script validation is manual.

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ This file is the authoritative registry of playlists. It enables PVC recovery an
 ### 5. Provision playlists (create .spotdl files)
 
 ```bash
-op run --env-file=.env.tpl -- docker compose run --rm -it pipeline music-provision
+just provision
 ```
 
 Or interactively add a single playlist:
 
 ```bash
-op run --env-file=.env.tpl -- docker compose run --rm -it pipeline music-setup
+just setup
 ```
 
 `music-setup` and `music-provision` are idempotent — they skip playlists whose `.spotdl` file already exists on the volume.
@@ -89,7 +89,7 @@ op run --env-file=.env.tpl -- docker compose run --rm -it pipeline music-setup
 ### 6. Start the service
 
 ```bash
-op run --env-file=.env.tpl -- docker compose up -d
+just up
 ```
 
 The container runs two cron jobs: `music-scan` every 5 minutes and `music-ingest` daily at 03:00 UTC. Override with `SCAN_CRON_SCHEDULE` and `SYNC_CRON_SCHEDULE` env vars.
@@ -98,21 +98,21 @@ To avoid rate limiting on large playlists, set `SYNC_TRACK_LIMIT` to cap total n
 
 ---
 
-## Host-side `just` recipes
+## `just` recipes
 
-These live in the dotfiles repo (`sometimeskind/dotfiles`) at `just/.justfile` → `~/.justfile`.
+A `justfile` lives in the repo root. Run these from the repo directory.
 
 | Recipe | What it does |
 |---|---|
-| `just sync` | Run full ingest now |
-| `just setup` | Add a new playlist (interactive) |
-| `just remove <name>` | Remove a playlist |
-| `just import` | Import files dropped into inbox |
-| `just rescan` | POST to Navidrome API to trigger library refresh |
-| `just logs` | Tail container logs |
 | `just up` | Start the container |
 | `just down` | Stop the container |
-| `just backup` | Dump beets DB + export JSON |
+| `just sync` | Run full ingest now |
+| `just setup` | Add a new playlist (interactive) |
+| `just provision` | Provision all playlists from `config/playlists.conf` (idempotent) |
+| `just remove <name>` | Remove a playlist |
+| `just import` | Import files dropped into inbox |
+| `just logs` | Tail container logs |
+| `just backup` | Dump beets DB + export JSON inside container |
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -4,7 +4,11 @@ sync:
 
 # Add a new playlist (interactive)
 setup:
-    op run --env-file .env.tpl -- docker compose exec -it pipeline music-setup
+    op run --env-file .env.tpl -- docker compose run --rm -it pipeline music-setup
+
+# Provision all playlists from config/playlists.conf (idempotent)
+provision:
+    op run --env-file .env.tpl -- docker compose run --rm -it pipeline music-provision
 
 # Remove a playlist: just remove <name>
 remove name:
@@ -13,11 +17,6 @@ remove name:
 # Import files dropped into inbox
 import:
     docker compose exec pipeline music-import
-
-# Trigger Navidrome library rescan
-# TODO: fill in Navidrome host, user, and password (store password in 1Password)
-# rescan:
-#     curl -s "http://<navidrome-host>/rest/startScan?u=<user>&p=<pass>&v=1.16.1&c=music-pipeline&f=json"
 
 # Tail container logs
 logs:
@@ -33,6 +32,5 @@ down:
 
 # Dump beets DB and export JSON from the container
 backup:
-    docker compose exec pipeline sh -c \
-        "beet export > /root/.config/beets/library-export.json && \
-         sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"
+    docker compose exec pipeline sh -c "beet export > /root/.config/beets/library-export.json"
+    docker compose exec pipeline sh -c "sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,38 @@
+# Run full ingest (download + import + M3U + quarantine)
+sync:
+    op run --env-file .env.tpl -- docker compose exec pipeline music-ingest
+
+# Add a new playlist (interactive)
+setup:
+    op run --env-file .env.tpl -- docker compose exec -it pipeline music-setup
+
+# Remove a playlist: just remove <name>
+remove name:
+    docker compose exec pipeline music-remove {{name}}
+
+# Import files dropped into inbox
+import:
+    docker compose exec pipeline music-import
+
+# Trigger Navidrome library rescan
+# TODO: fill in Navidrome host, user, and password (store password in 1Password)
+# rescan:
+#     curl -s "http://<navidrome-host>/rest/startScan?u=<user>&p=<pass>&v=1.16.1&c=music-pipeline&f=json"
+
+# Tail container logs
+logs:
+    docker compose logs -f pipeline
+
+# Start the pipeline container
+up:
+    op run --env-file .env.tpl -- docker compose up -d
+
+# Stop the pipeline container
+down:
+    docker compose down
+
+# Dump beets DB and export JSON from the container
+backup:
+    docker compose exec pipeline sh -c \
+        "beet export > /root/.config/beets/library-export.json && \
+         sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"


### PR DESCRIPTION
## Summary
- Moves `just` recipes from the dotfiles repo into this project where they belong
- Simplifies paths — recipes now use relative paths since `just` runs from the project root
- Removes the hardcoded `music_pipeline` variable that pointed to `~/src/music-pipeline`

## Test plan
- [ ] `just up` starts the pipeline container
- [ ] `just sync` runs a full ingest
- [ ] `just logs` tails container output
- [ ] `just down` stops the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)