### PR TITLE
docs: add end-to-end manual test plan

### DIFF
--- a/docs/manual-test-plan.md
+++ b/docs/manual-test-plan.md
@@ -1,0 +1,270 @@
+# Manual Test Plan
+
+End-to-end verification for the music pipeline. Run these scenarios top-to-bottom against a running container to confirm the full data flow is working.
+
+## Prerequisites
+
+- Container built: `docker compose build`
+- `cookies.txt` present on the host (YouTube Premium cookies)
+- 1Password CLI (`op`) configured with Spotify credentials (required only for Scenarios 1, 5)
+- A few test audio files ready to drop in — see [Test Audio Files](#test-audio-files) below
+
+---
+
+## Test Audio Files
+
+You need two types of files:
+
+**Case A — Well-known track (will match MusicBrainz):**
+A freely licensed .mp3 or .m4a from a release indexed in MusicBrainz. Good sources:
+- [Jamendo](https://www.jamendo.com) — Creative Commons releases, many with MusicBrainz entries
+- Any CC-BY or CC0 album you can find on MusicBrainz directly
+
+**Case B — Unknown track (will be quarantined):**
+A short noise or silence file that won't match anything. Generate one with:
+```bash
+ffmpeg -f lavfi -i "anoisesrc=d=5" -ar 44100 noise.mp3
+```
+
+---
+
+## Scenario 1 — Container Startup & Cron Verification
+
+**Goal:** Confirm the service starts and both cron jobs are registered.
+
+```bash
+just up
+just logs    # look for cron daemon starting
+```
+
+Verify cron entries are registered:
+```bash
+docker compose exec pipeline crontab -l
+```
+
+Expected output: two entries — one for `music-scan` (every 5 min by default), one for `music-ingest` (03:00 UTC by default).
+
+Wait ~5 minutes, then check logs for a `music-scan` run:
+```bash
+just logs
+```
+
+**Pass criteria:**
+- Two cron entries visible matching `SCAN_CRON_SCHEDULE` and `SYNC_CRON_SCHEDULE`
+- `music-scan` fires and exits cleanly; logs show "Imported 0 items" (inbox is empty)
+
+---
+
+## Scenario 2 — Manual File Drop into Inbox
+
+**Goal:** Verify beets import, library placement, quarantine, and inbox cleanup — without Spotify or YouTube.
+
+> This is the most important scenario to run first. It does not require credentials.
+
+### Steps
+
+**1. Copy test files into the inbox:**
+```bash
+docker compose cp track-a.mp3 pipeline:/root/Music/inbox/
+docker compose cp noise.mp3 pipeline:/root/Music/inbox/
+```
+
+**2. Trigger an import:**
+```bash
+just import
+```
+
+**3. Verify Case A (well-known track) was imported to the library:**
+```bash
+docker compose exec pipeline beet ls -a
+# should list the track with artist/album/title populated
+
+docker compose exec pipeline find /root/Music/library -type f
+# should show: /root/Music/library/<albumartist>/<album>/<track> - <title>.*
+```
+
+**4. Verify Case B (unknown track) went to quarantine:**
+```bash
+docker compose exec pipeline find /root/Music/quarantine -type f
+# noise.mp3 should appear here
+```
+
+**5. Verify inbox is clear:**
+```bash
+docker compose exec pipeline find /root/Music/inbox -maxdepth 1 -type f
+# should be empty — files have been moved out
+```
+
+**6. Check the import log for match decisions:**
+```bash
+docker compose exec pipeline tail -50 /root/.config/beets/import.log
+# shows confidence scores and import/skip/quarantine decisions per file
+```
+
+**Pass criteria:**
+- Case A in library at `$albumartist/$album/$track - $title.*`
+- Case B in quarantine (`/root/Music/quarantine/`)
+- Inbox empty after import
+- Import log shows confidence scores and a decision for each file
+
+**If too many good tracks go to quarantine:** raise `strong_rec_thresh` in `config/beets/config.yaml` from `0.05` toward `0.10` and re-test.
+
+---
+
+## Scenario 3 — Simulated spotdl Playlist Import
+
+**Goal:** Verify `source=<name>` tagging and `.m3u` generation — without Spotify or YouTube.
+
+### Steps
+
+**1. Create a fake spotdl playlist directory:**
+```bash
+docker compose exec pipeline mkdir -p /root/Music/inbox/spotdl/test-playlist
+```
+
+**2. Drop a well-known track into it (simulating a spotdl download):**
+```bash
+docker compose cp track-a.mp3 pipeline:/root/Music/inbox/spotdl/test-playlist/
+```
+
+**3. Create a minimal `.spotdl` state file:**
+```bash
+docker compose exec pipeline sh -c 'echo "{\"songs\": []}" > /root/Music/inbox/spotdl/test-playlist.spotdl'
+```
+
+**4. Run a scan:**
+```bash
+docker compose exec pipeline music-scan
+```
+
+**5. Verify the `source` tag was applied:**
+```bash
+docker compose exec pipeline beet ls -a source:test-playlist
+# should list the imported track
+```
+
+**6. Verify the `.m3u` was generated:**
+```bash
+docker compose exec pipeline cat /root/Music/playlists/test-playlist.m3u
+# should contain a relative path to the imported track
+```
+
+**Pass criteria:**
+- Track tagged `source=test-playlist` in beets DB
+- `/root/Music/playlists/test-playlist.m3u` exists and contains a relative path to the track
+
+---
+
+## Scenario 4 — Duplicate Handling
+
+**Goal:** Verify that re-importing an already-present track is skipped correctly.
+
+> Run after Scenario 2 or 3.
+
+### Steps
+
+**1. Drop the same well-known track into the inbox again:**
+```bash
+docker compose cp track-a.mp3 pipeline:/root/Music/inbox/
+```
+
+**2. Run import again:**
+```bash
+just import
+```
+
+**3. Check the import log for a skip/duplicate decision:**
+```bash
+docker compose exec pipeline tail -20 /root/.config/beets/import.log
+```
+
+**4. Confirm there is only one copy in the library:**
+```bash
+docker compose exec pipeline beet ls -a title:<track-title>
+# should show exactly one entry
+```
+
+**Pass criteria:**
+- Import log shows the file was skipped or identified as a duplicate
+- Beets DB has exactly one entry for the track
+- No second file written to the library
+
+---
+
+## Scenario 5 — Full Ingest with Spotify
+
+**Goal:** Verify the complete `spotdl sync → import → .m3u` flow with a real playlist.
+
+> Requires `op` and Spotify credentials. Use a small playlist (≤10 tracks) to keep the test fast.
+
+### Steps
+
+**1. Add a test playlist to `config/playlists.conf`:**
+```
+test-small  https://open.spotify.com/playlist/<id>
+```
+
+**2. Provision it (creates the `.spotdl` state file):**
+```bash
+just provision
+```
+
+**3. Run a full ingest:**
+```bash
+just sync
+```
+
+**4. Verify tracks are in the library with the correct tag:**
+```bash
+docker compose exec pipeline beet ls -a source:test-small
+```
+
+**5. Verify the `.m3u` was generated:**
+```bash
+docker compose exec pipeline cat /root/Music/playlists/test-small.m3u
+```
+
+**6. If `NAVIDROME_URL` is set — check logs for rescan confirmation:**
+```bash
+just logs | grep -i navidrome
+# expect: "Navidrome rescan triggered successfully"
+```
+
+**7. If `PUSHGATEWAY_URL` is set — check Prometheus for metrics:**
+Look for `music_scan_*` metrics in the Pushgateway UI.
+
+**Pass criteria:**
+- All playlist tracks imported to library
+- Each track tagged `source=test-small`
+- `.m3u` populated with correct relative paths
+- Optional integrations (Navidrome, Prometheus) confirmed in logs/UI
+
+---
+
+## Cleanup After Testing
+
+Remove test data to leave the environment clean:
+
+```bash
+# Remove the fake test playlist added in Scenario 3
+just remove test-playlist
+
+# Remove the small Spotify test playlist added in Scenario 5 (if added)
+# First edit config/playlists.conf to remove the entry, then:
+just remove test-small
+
+# Clear quarantine manually
+docker compose exec pipeline rm -rf /root/Music/quarantine/*
+```
+
+---
+
+## Key Files for Debugging
+
+| File | Purpose |
+|---|---|
+| `/root/.config/beets/import.log` | Per-file import decisions and confidence scores |
+| `/root/.config/beets/library.db` | Beets SQLite DB — query with `beet ls` or `sqlite3` |
+| `/root/Music/quarantine/` | Files that didn't meet the MusicBrainz match threshold |
+| `/root/Music/playlists/` | Generated `.m3u` files |
+| `config/beets/config.yaml` | Match threshold (`strong_rec_thresh`), library paths |


### PR DESCRIPTION
## Summary

- Adds `docs/manual-test-plan.md` with five end-to-end test scenarios covering the full pipeline data flow
- Scenarios 2–4 require no credentials and can be run against a local container immediately
- Scenario 5 covers the full Spotify ingest path (requires 1Password/credentials)

## Scenarios

| # | Name | Credentials needed |
|---|---|---|
| 1 | Container startup & cron verification | yes (`just up` needs `op`) |
| 2 | Manual file drop into inbox | none |
| 3 | Simulated spotdl playlist import | none |
| 4 | Duplicate handling | none |
| 5 | Full ingest with Spotify | yes |

## Test plan

- [ ] Follow Scenario 2 (manual file drop) against a running container — verify well-known track lands in library, noise file lands in quarantine, inbox is empty after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)