### PR TITLE
feat: split into fetch and scan containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/music-pipeline
-
 jobs:
   test:
     name: Unit Tests
@@ -51,58 +48,104 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
+      # --- fetch image ---
+
+      - name: Extract metadata (fetch)
+        id: meta-fetch
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ github.repository_owner }}/music-pipeline-fetch
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
 
-      - name: Build image (load for health checks)
+      - name: Build fetch image
         uses: docker/build-push-action@v7
         with:
           context: .
+          target: fetch
           push: false
           load: true
           tags: |
-            ${{ steps.meta.outputs.tags }}
-            music-pipeline:ci-local
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ steps.meta-fetch.outputs.tags }}
+            music-pipeline-fetch:ci-local
+          labels: ${{ steps.meta-fetch.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Health check — beet
-        run: docker run --rm --entrypoint beet music-pipeline:ci-local version
-
       - name: Health check — spotdl
-        run: docker run --rm --entrypoint spotdl music-pipeline:ci-local --version
+        run: docker run --rm --entrypoint spotdl music-pipeline-fetch:ci-local --version
 
-      - name: Health check — ffmpeg
-        run: docker run --rm --entrypoint ffmpeg music-pipeline:ci-local -version
-
-      - name: Health check — fpcalc
-        run: docker run --rm --entrypoint fpcalc music-pipeline:ci-local -version
-
-      - name: Health check — pipeline commands
+      - name: Health check — fetch commands
         run: |
-          docker run --rm music-pipeline:ci-local sh -c "
-            which music-scan &&
+          docker run --rm music-pipeline-fetch:ci-local sh -c "
             which music-ingest &&
-            which music-import &&
             which music-setup &&
-            which music-remove &&
             which music-provision
           "
 
-      - name: Push to GHCR
+      - name: Push fetch image to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v7
         with:
           context: .
+          target: fetch
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-fetch.outputs.tags }}
+          labels: ${{ steps.meta-fetch.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # --- scan image ---
+
+      - name: Extract metadata (scan)
+        id: meta-scan
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/music-pipeline-scan
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,format=short
+
+      - name: Build scan image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: scan
+          push: false
+          load: true
+          tags: |
+            ${{ steps.meta-scan.outputs.tags }}
+            music-pipeline-scan:ci-local
+          labels: ${{ steps.meta-scan.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Health check — beet
+        run: docker run --rm --entrypoint beet music-pipeline-scan:ci-local version
+
+      - name: Health check — ffmpeg
+        run: docker run --rm --entrypoint ffmpeg music-pipeline-scan:ci-local -version
+
+      - name: Health check — fpcalc
+        run: docker run --rm --entrypoint fpcalc music-pipeline-scan:ci-local -version
+
+      - name: Health check — scan commands
+        run: |
+          docker run --rm music-pipeline-scan:ci-local sh -c "
+            which music-scan &&
+            which music-import &&
+            which music-remove
+          "
+
+      - name: Push scan image to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: scan
+          push: true
+          tags: ${{ steps.meta-scan.outputs.tags }}
+          labels: ${{ steps.meta-scan.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 *.pyc
 *.egg-info/
 .pytest_cache/
+.venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A Dockerized music pipeline: Spotify playlists → spotdl downloads → beets import/tagging → Navidrome music server. Scheduling is handled externally (k8s CronJobs); the container runs a single task and exits.
+A Dockerized music pipeline: Spotify playlists → spotdl downloads → beets import/tagging → Navidrome music server. Scheduling is handled externally (k8s CronJobs); each container runs a single task and exits.
+
+The pipeline runs as two containers:
+- **fetch** (`music-pipeline-fetch`) — spotdl sync, Spotify/YouTube network calls; no beets/ffmpeg
+- **scan** (`music-pipeline-scan`) — beets import, AcoustID fingerprinting, .m3u generation, Navidrome rescan
 
 **Data flow:**
 ```
-Spotify playlists → spotdl sync → /root/Music/inbox/spotdl/<name>/ → beets import → /root/Music/library/$albumartist/$album/$track - $title.m4a → Navidrome (via NFS)
+Spotify playlists → [fetch] spotdl sync → /root/Music/inbox/spotdl/<name>/ → [scan] beets import → /root/Music/library/$albumartist/$album/$track - $title.m4a → Navidrome (via NFS)
 ```
+
+Removed-track info is passed between containers via `/root/Music/inbox/.pending-removals.json` on the shared volume. The fetch container writes it; music-scan reads and processes it, then deletes it.
 
 ## Common Commands
 
@@ -22,20 +28,23 @@ just hooks
 # Run the test suite (builds the dev container, runs pytest)
 just test
 
-# Build the production container image
+# Build both container images
 docker compose build
 
-# Interactive: add a new playlist
+# Interactive: add a new playlist (runs in fetch container)
 just setup
 
-# Provision all playlists from config/playlists.conf (idempotent)
+# Provision all playlists from config/playlists.conf (idempotent, fetch container)
 just provision
 
-# Run a full ingest (spotdl sync → import → .m3u → Navidrome rescan)
-just sync
+# Run spotdl sync only (fetch container: Spotify/YouTube → inbox)
+just fetch
 
-# Run a local scan only (import inbox → .m3u → Navidrome rescan, no Spotify/YouTube)
+# Run a local scan only (scan container: import inbox → .m3u → Navidrome rescan)
 just scan
+
+# Run full ingest: just fetch && just scan
+just sync
 ```
 
 **Do not run Python commands directly on the host.** All Python tooling (pytest, beet, spotdl) runs inside the container. Use `just test` to run tests.
@@ -91,10 +100,15 @@ A `pre-push` git hook runs `just test` automatically before every push. Install 
 
 ### Environment Variables
 
-- `SYNC_TRACK_LIMIT` — If set, caps the total number of new tracks downloaded across all playlists in a single `music-ingest` run. Playlists are processed in alphabetical order; the budget is shared. Tracks deferred by the limit are excluded from the `.spotdl` snapshot and re-appear as new on the next run. Useful for large playlists (e.g. liked songs) to avoid rate limiting. Default: unset (no limit).
-- `PUSHGATEWAY_URL` — Prometheus Pushgateway URL (e.g. `http://pushgateway:9091`). If unset, metrics are not pushed.
+**fetch container:**
 - `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` — Injected via 1Password at runtime.
+- `SYNC_TRACK_LIMIT` — If set, caps the total number of new tracks downloaded across all playlists in a single `music-ingest` run. Playlists are processed in alphabetical order; the budget is shared. Tracks deferred by the limit are excluded from the `.spotdl` snapshot and re-appear as new on the next run. Useful for large playlists (e.g. liked songs) to avoid rate limiting. Default: unset (no limit).
+- `SYNC_JITTER_SECONDS` — If set, sleeps a random 0–N seconds before syncing to spread load. Default: unset.
+- `PUSHGATEWAY_URL` — Prometheus Pushgateway URL (e.g. `http://pushgateway:9091`). If unset, metrics are not pushed.
+
+**scan container:**
 - `NAVIDROME_URL` / `NAVIDROME_API_KEY` — Optional Navidrome rescan trigger. `NAVIDROME_API_KEY` format: `user:password`.
+- `PUSHGATEWAY_URL` — Prometheus Pushgateway URL. If unset, metrics are not pushed.
 
 ### `.m3u` Playlists
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,26 @@
-FROM python:3.13-slim AS prod
+# fetch stage: spotdl sync, Spotify/YouTube network calls.
+# No ffmpeg or chromaprint needed — beets is not installed here.
+FROM python:3.13-slim AS fetch
+
+# Python dependencies: pinned in requirements-fetch.txt for Dependabot tracking
+COPY requirements-fetch.txt /requirements-fetch.txt
+RUN pip install --no-cache-dir -r /requirements-fetch.txt
+
+# Install the pipeline package — entry points land in /usr/local/bin/
+COPY pipeline/ /app/pipeline/
+COPY pyproject.toml /app/pyproject.toml
+RUN pip install --no-cache-dir -e /app
+
+# Pre-create directories that will be populated by volume mounts
+RUN mkdir -p \
+    /root/Music/inbox/spotdl \
+    /root/.config/spotdl \
+    /root/.config/music-pipeline
+
+
+# scan stage: beets import, AcoustID fingerprinting, .m3u generation, Navidrome rescan.
+# No Spotify or YouTube calls — reads inbox written by the fetch container.
+FROM python:3.13-slim AS scan
 
 # System dependencies: ffmpeg for audio processing, chromaprint for AcoustID fingerprinting.
 RUN apt-get update && apt-get install -y \
@@ -6,9 +28,9 @@ RUN apt-get update && apt-get install -y \
     libchromaprint-tools \
     && rm -rf /var/lib/apt/lists/*
 
-# Python dependencies: pinned in requirements.txt for Dependabot tracking
-COPY requirements.txt /requirements.txt
-RUN pip install --no-cache-dir -r /requirements.txt
+# Python dependencies: pinned in requirements-scan.txt for Dependabot tracking
+COPY requirements-scan.txt /requirements-scan.txt
+RUN pip install --no-cache-dir -r /requirements-scan.txt
 
 # Install the pipeline package — entry points land in /usr/local/bin/
 COPY pipeline/ /app/pipeline/
@@ -22,11 +44,11 @@ RUN mkdir -p \
     /root/Music/quarantine \
     /root/Music/playlists \
     /root/.config/beets \
-    /root/.config/spotdl \
-    /root/.config/music-pipeline
+    /root/.config/spotdl
 
-# dev stage: prod + test deps; used by `just test`, never pushed to registry
-FROM prod AS dev
+
+# dev stage: scan + all fetch deps + test deps; used by `just test`, never pushed to registry
+FROM scan AS dev
 COPY requirements-dev.txt /requirements-dev.txt
 RUN pip install --no-cache-dir -r /requirements-dev.txt
 COPY tests/ /app/tests/

--- a/compose.yml
+++ b/compose.yml
@@ -1,13 +1,12 @@
 services:
-  pipeline:
-    image: ghcr.io/sometimeskind/music-pipeline:latest
+  fetch:
+    build:
+      context: .
+      target: fetch
+    image: ghcr.io/sometimeskind/music-pipeline-fetch:latest
     volumes:
-      # Music data: inbox, library, quarantine, playlists
+      # Music data: inbox shared with scan container for downloaded files and pending-removals.json
       - music-data:/root/Music
-      # Beets database and import log (SQLite — back this up)
-      - beets-data:/root/.config/beets
-      # Beets config (from this repo)
-      - ./config/beets/config.yaml:/root/.config/beets/config.yaml:ro
       # spotdl config (from this repo)
       - ./config/spotdl/config.json:/root/.config/spotdl/config.json:ro
       # Playlist registry (from this repo; k8s: mount as ConfigMap)
@@ -19,6 +18,26 @@ services:
       # Inject Spotify credentials at runtime via: op run --env-file=.env.tpl -- docker compose run ...
       - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
+      # Optional: cap total new downloads per run across all playlists
+      - SYNC_TRACK_LIMIT=${SYNC_TRACK_LIMIT:-}
+      # Optional: random delay before syncing to spread load (seconds)
+      - SYNC_JITTER_SECONDS=${SYNC_JITTER_SECONDS:-}
+      # Optional: Prometheus Pushgateway URL for job metrics
+      - PUSHGATEWAY_URL=${PUSHGATEWAY_URL:-}
+
+  scan:
+    build:
+      context: .
+      target: scan
+    image: ghcr.io/sometimeskind/music-pipeline-scan:latest
+    volumes:
+      # Music data: inbox shared with fetch container, plus library/quarantine/playlists
+      - music-data:/root/Music
+      # Beets database and import log (SQLite — back this up)
+      - beets-data:/root/.config/beets
+      # Beets config (from this repo)
+      - ./config/beets/config.yaml:/root/.config/beets/config.yaml:ro
+    environment:
       # Optional: Prometheus Pushgateway URL for job metrics
       - PUSHGATEWAY_URL=${PUSHGATEWAY_URL:-}
       # Optional: trigger Navidrome library rescan after each scan

--- a/docs/manual-test-plan.md
+++ b/docs/manual-test-plan.md
@@ -52,8 +52,8 @@ just scan
 
 **1. Copy test files into the inbox:**
 ```bash
-docker compose cp track-a.mp3 pipeline:/root/Music/inbox/
-docker compose cp noise.mp3 pipeline:/root/Music/inbox/
+docker compose cp track-a.mp3 scan:/root/Music/inbox/
+docker compose cp noise.mp3 scan:/root/Music/inbox/
 ```
 
 **2. Trigger an import:**
@@ -63,28 +63,28 @@ just import
 
 **3. Verify Case A (well-known track) was imported to the library:**
 ```bash
-docker compose run --rm pipeline beet ls -a
+docker compose run --rm scan beet ls -a
 # should list the track with artist/album/title populated
 
-docker compose run --rm pipeline find /root/Music/library -type f
+docker compose run --rm scan find /root/Music/library -type f
 # should show: /root/Music/library/<albumartist>/<album>/<track> - <title>.*
 ```
 
 **4. Verify Case B (unknown track) went to quarantine:**
 ```bash
-docker compose run --rm pipeline find /root/Music/quarantine -type f
+docker compose run --rm scan find /root/Music/quarantine -type f
 # noise.mp3 should appear here
 ```
 
 **5. Verify inbox is clear:**
 ```bash
-docker compose run --rm pipeline find /root/Music/inbox -maxdepth 1 -type f
+docker compose run --rm scan find /root/Music/inbox -maxdepth 1 -type f
 # should be empty — files have been moved out
 ```
 
 **6. Check the import log for match decisions:**
 ```bash
-docker compose run --rm pipeline tail -50 /root/.config/beets/import.log
+docker compose run --rm scan tail -50 /root/.config/beets/import.log
 # shows confidence scores and import/skip/quarantine decisions per file
 ```
 
@@ -106,17 +106,17 @@ docker compose run --rm pipeline tail -50 /root/.config/beets/import.log
 
 **1. Create a fake spotdl playlist directory:**
 ```bash
-docker compose run --rm pipeline mkdir -p /root/Music/inbox/spotdl/test-playlist
+docker compose run --rm scan mkdir -p /root/Music/inbox/spotdl/test-playlist
 ```
 
 **2. Drop a well-known track into it (simulating a spotdl download):**
 ```bash
-docker compose cp track-a.mp3 pipeline:/root/Music/inbox/spotdl/test-playlist/
+docker compose cp track-a.mp3 scan:/root/Music/inbox/spotdl/test-playlist/
 ```
 
 **3. Create a minimal `.spotdl` state file:**
 ```bash
-docker compose run --rm pipeline sh -c 'echo "{\"songs\": []}" > /root/Music/inbox/spotdl/test-playlist.spotdl'
+docker compose run --rm scan sh -c 'echo "{\"songs\": []}" > /root/Music/inbox/spotdl/test-playlist.spotdl'
 ```
 
 **4. Run a scan:**
@@ -126,13 +126,13 @@ just scan
 
 **5. Verify the `source` tag was applied:**
 ```bash
-docker compose run --rm pipeline beet ls -a source:test-playlist
+docker compose run --rm scan beet ls -a source:test-playlist
 # should list the imported track
 ```
 
 **6. Verify the `.m3u` was generated:**
 ```bash
-docker compose run --rm pipeline cat /root/Music/playlists/test-playlist.m3u
+docker compose run --rm scan cat /root/Music/playlists/test-playlist.m3u
 # should contain a relative path to the imported track
 ```
 
@@ -152,7 +152,7 @@ docker compose run --rm pipeline cat /root/Music/playlists/test-playlist.m3u
 
 **1. Drop the same well-known track into the inbox again:**
 ```bash
-docker compose cp track-a.mp3 pipeline:/root/Music/inbox/
+docker compose cp track-a.mp3 scan:/root/Music/inbox/
 ```
 
 **2. Run import again:**
@@ -162,12 +162,12 @@ just import
 
 **3. Check the import log for a skip/duplicate decision:**
 ```bash
-docker compose run --rm pipeline tail -20 /root/.config/beets/import.log
+docker compose run --rm scan tail -20 /root/.config/beets/import.log
 ```
 
 **4. Confirm there is only one copy in the library:**
 ```bash
-docker compose run --rm pipeline beet ls -a title:<track-title>
+docker compose run --rm scan beet ls -a title:<track-title>
 # should show exactly one entry
 ```
 
@@ -203,12 +203,12 @@ just sync
 
 **4. Verify tracks are in the library with the correct tag:**
 ```bash
-docker compose run --rm pipeline beet ls -a source:test-small
+docker compose run --rm scan beet ls -a source:test-small
 ```
 
 **5. Verify the `.m3u` was generated:**
 ```bash
-docker compose run --rm pipeline cat /root/Music/playlists/test-small.m3u
+docker compose run --rm scan cat /root/Music/playlists/test-small.m3u
 ```
 
 **6. If `NAVIDROME_URL` is set — check logs for rescan confirmation:**
@@ -241,7 +241,7 @@ just remove test-playlist
 just remove test-small
 
 # Clear quarantine manually
-docker compose run --rm pipeline rm -rf /root/Music/quarantine/*
+docker compose run --rm scan rm -rf /root/Music/quarantine/*
 ```
 
 ---

--- a/justfile
+++ b/justfile
@@ -7,31 +7,35 @@ test:
 hooks:
     git config core.hooksPath .githooks
 
-# Run full ingest: spotdl sync → import → .m3u → Navidrome rescan
-sync:
-    op run --env-file .env.tpl -- docker compose run --rm pipeline music-ingest
+# Run spotdl sync (fetch container: Spotify/YouTube → inbox)
+fetch:
+    op run --env-file .env.tpl -- docker compose run --rm fetch music-ingest
 
 # Run a local scan: import inbox → .m3u → Navidrome rescan (no Spotify/YouTube)
 scan:
-    docker compose run --rm pipeline music-scan
+    docker compose run --rm scan music-scan
+
+# Run full ingest: spotdl sync → import → .m3u → Navidrome rescan
+sync:
+    just fetch && just scan
 
 # Import files dropped into inbox (subset of scan)
 import:
-    docker compose run --rm pipeline music-import
+    docker compose run --rm scan music-import
 
 # Add a new playlist (interactive)
 setup:
-    op run --env-file .env.tpl -- docker compose run --rm -it pipeline music-setup
+    op run --env-file .env.tpl -- docker compose run --rm -it fetch music-setup
 
 # Provision all playlists from config/playlists.conf (idempotent)
 provision:
-    op run --env-file .env.tpl -- docker compose run --rm pipeline music-provision
+    op run --env-file .env.tpl -- docker compose run --rm fetch music-provision
 
 # Remove a playlist: just remove <name>
 remove name:
-    docker compose run --rm pipeline music-remove {{name}}
+    docker compose run --rm scan music-remove {{name}}
 
 # Dump beets DB and export JSON from the container
 backup:
-    docker compose run --rm pipeline sh -c "beet export > /root/.config/beets/library-export.json"
-    docker compose run --rm pipeline sh -c "sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"
+    docker compose run --rm scan sh -c "beet export > /root/.config/beets/library-export.json"
+    docker compose run --rm scan sh -c "sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -105,7 +105,7 @@ def setup() -> None:
     if not os.environ.get("SPOTIFY_CLIENT_ID") or not os.environ.get("SPOTIFY_CLIENT_SECRET"):
         print("Error: SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set", file=sys.stderr)
         print(
-            "Run via: op run --env-file=.env.tpl -- docker compose run --rm pipeline music-setup",
+            "Run via: op run --env-file=.env.tpl -- docker compose run --rm fetch music-setup",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/pipeline/ingest.py
+++ b/pipeline/ingest.py
@@ -113,11 +113,16 @@ def _write_pending_removals(pending: list[dict]) -> None:
         try:
             with open(PENDING_REMOVALS, encoding="utf-8") as fh:
                 existing = json.load(fh)
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error("Could not read %s — discarding prior pending removals: %s", PENDING_REMOVALS, exc)
             existing = []
 
-    with open(PENDING_REMOVALS, "w", encoding="utf-8") as fh:
+    # Atomic write: write to a temp file then rename so a mid-write failure never
+    # truncates the existing file.
+    tmp = PENDING_REMOVALS.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
         json.dump(existing + pending, fh, indent=2, ensure_ascii=False)
+    tmp.replace(PENDING_REMOVALS)
 
     logger.info("==> Wrote %d pending removal(s) to %s", len(pending), PENDING_REMOVALS)
 

--- a/pipeline/ingest.py
+++ b/pipeline/ingest.py
@@ -1,24 +1,23 @@
-"""music-ingest: daily spotdl sync loop → music-scan.
+"""music-ingest: daily spotdl sync loop → write pending-removals for music-scan.
 
 For each .spotdl playlist:
 1. Load the current .spotdl snapshot (old songs).
 2. Fetch the current Spotify playlist state (new songs) via spotdl library.
 3. Download new tracks (overwrite=skip ignores already-downloaded files).
 4. Diff old vs new URL sets to find removed tracks.
-5. Clear beets source tags for removed tracks (soft delete — files stay in library).
-Then calls music-scan to import + tag + generate playlists.
+5. Write removed track info to .pending-removals.json on the shared volume.
+   music-scan reads this file to clear beets source tags (soft delete — files stay in library).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
 import time
 from pathlib import Path
 
-import pipeline.scan as scan_module
-from pipeline.library import MusicLibrary
 from pipeline.metrics import IngestMetrics
 from pipeline.spotdl_ops import find_track_in_snapshot, sync_playlist
 
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
 COOKIE_FILE = Path("/root/.config/spotdl/cookies.txt")
-LIBRARY_DB = Path("/root/.config/beets/library.db")
+PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
 
 
 def classify_failure(error_msg: str) -> str:
@@ -73,17 +72,21 @@ def _jitter() -> None:
         time.sleep(delay)
 
 
-def _remove_source_tags(
-    lib: MusicLibrary,
+def _collect_removals(
+    pending: list[dict],
     removed_urls: set[str],
     old_songs: list[dict],
     playlist_name: str,
 ) -> None:
-    """Clear beets source tags for all removed track URLs."""
+    """Collect removed track info for deferred beets tag cleanup by music-scan."""
     if not removed_urls:
         return
 
-    logger.info("==> Unlinking %d removed track(s) from playlist: %s", len(removed_urls), playlist_name)
+    logger.info(
+        "==> Scheduling unlinking of %d removed track(s) from playlist: %s",
+        len(removed_urls),
+        playlist_name,
+    )
     for url in removed_urls:
         entry = find_track_in_snapshot(old_songs, url)
         if entry is None:
@@ -93,19 +96,34 @@ def _remove_source_tags(
         title = entry.get("name", "")
         artists = entry.get("artists", [])
         artist = artists[0] if artists else ""
-        logger.info("  Unlinking: %s — %s", title, artist)
+        logger.info("  Scheduling unlink: %s — %s", title, artist)
+        pending.append({"title": title, "artist": artist, "source": playlist_name})
 
-        found = lib.clear_source_tag(title=title, artist=artist, source=playlist_name)
-        if not found:
-            logger.warning(
-                "  WARNING: not found in beets — may need manual cleanup: %s by %s", title, artist
-            )
+
+def _write_pending_removals(pending: list[dict]) -> None:
+    """Append pending source-tag removals to the shared volume for music-scan."""
+    if not pending:
+        return
+
+    PENDING_REMOVALS.parent.mkdir(parents=True, exist_ok=True)
+
+    # Load and append — safe if fetch runs multiple times before scan processes the file.
+    existing: list[dict] = []
+    if PENDING_REMOVALS.exists():
+        try:
+            with open(PENDING_REMOVALS, encoding="utf-8") as fh:
+                existing = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            existing = []
+
+    with open(PENDING_REMOVALS, "w", encoding="utf-8") as fh:
+        json.dump(existing + pending, fh, indent=2, ensure_ascii=False)
+
+    logger.info("==> Wrote %d pending removal(s) to %s", len(pending), PENDING_REMOVALS)
 
 
 def run() -> None:
     """Execute the full ingest pipeline, push metrics on completion."""
-    import json
-
     metrics = IngestMetrics()
     start = time.monotonic()
 
@@ -141,68 +159,68 @@ def run() -> None:
         if not spotdl_files:
             logger.info("No .spotdl files found in %s", SPOTDL_DIR)
 
-        with MusicLibrary(LIBRARY_DB) as lib:
-            for spotdl_file in spotdl_files:
-                name = spotdl_file.stem
+        pending_removals: list[dict] = []
 
-                # .nosync: skip spotdl sync for frozen playlists
-                if (SPOTDL_DIR / f"{name}.nosync").exists():
-                    logger.info("==> Skipping sync for static playlist: %s (.nosync present)", name)
-                    metrics.playlists_skipped += 1
-                    metrics.playlists_total += 1
-                    continue
+        for spotdl_file in spotdl_files:
+            name = spotdl_file.stem
 
-                # Budget exhausted: defer remaining playlists to the next session.
-                if remaining is not None and remaining <= 0:
-                    logger.info("==> Track budget exhausted — deferring %s to next session", name)
-                    metrics.playlists_deferred += 1
-                    metrics.playlists_total += 1
-                    continue
-
-                # Validate JSON before we attempt a sync
-                try:
-                    with open(spotdl_file, encoding="utf-8") as fh:
-                        sync_data = json.load(fh)
-                except json.JSONDecodeError:
-                    logger.warning("WARNING: %s is not valid JSON — skipping", spotdl_file)
-                    metrics.playlists_total += 1
-                    continue
-
-                old_songs: list[dict] = sync_data.get("songs", [])
-
-                logger.info("==> Syncing playlist: %s", name)
+            # .nosync: skip spotdl sync for frozen playlists
+            if (SPOTDL_DIR / f"{name}.nosync").exists():
+                logger.info("==> Skipping sync for static playlist: %s (.nosync present)", name)
+                metrics.playlists_skipped += 1
                 metrics.playlists_total += 1
-                output_dir = SPOTDL_DIR / name
-                output_dir.mkdir(parents=True, exist_ok=True)
+                continue
 
-                try:
-                    removed_urls, tracks_sent = sync_playlist(
-                        spotdl_file=spotdl_file,
-                        output_dir=output_dir,
-                        cookie_file=COOKIE_FILE,
-                        track_limit=remaining,
-                    )
-                except Exception as exc:
-                    reason = classify_failure(str(exc))
-                    logger.error(
-                        "ERROR: spotdl sync failed for %s (reason=%s): %s", name, reason, exc
-                    )
-                    metrics.success = False
-                    metrics.failure_reason = reason
-                    raise
+            # Budget exhausted: defer remaining playlists to the next session.
+            if remaining is not None and remaining <= 0:
+                logger.info("==> Track budget exhausted — deferring %s to next session", name)
+                metrics.playlists_deferred += 1
+                metrics.playlists_total += 1
+                continue
 
-                if remaining is not None:
-                    remaining -= tracks_sent
+            # Validate JSON before we attempt a sync
+            try:
+                with open(spotdl_file, encoding="utf-8") as fh:
+                    sync_data = json.load(fh)
+            except json.JSONDecodeError:
+                logger.warning("WARNING: %s is not valid JSON — skipping", spotdl_file)
+                metrics.playlists_total += 1
+                continue
 
-                _remove_source_tags(lib, removed_urls, old_songs, name)
+            old_songs: list[dict] = sync_data.get("songs", [])
 
-                # Brief pause between playlists — avoid hammering Spotify/YouTube APIs.
-                time.sleep(5)
+            logger.info("==> Syncing playlist: %s", name)
+            metrics.playlists_total += 1
+            output_dir = SPOTDL_DIR / name
+            output_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info("==> Sync complete. Calling music-scan for local import and playlist generation...")
-        scan_module.run()
+            try:
+                removed_urls, tracks_sent = sync_playlist(
+                    spotdl_file=spotdl_file,
+                    output_dir=output_dir,
+                    cookie_file=COOKIE_FILE,
+                    track_limit=remaining,
+                )
+            except Exception as exc:
+                reason = classify_failure(str(exc))
+                logger.error(
+                    "ERROR: spotdl sync failed for %s (reason=%s): %s", name, reason, exc
+                )
+                metrics.success = False
+                metrics.failure_reason = reason
+                raise
 
-        logger.info("==> music-ingest complete")
+            if remaining is not None:
+                remaining -= tracks_sent
+
+            _collect_removals(pending_removals, removed_urls, old_songs, name)
+
+            # Brief pause between playlists — avoid hammering Spotify/YouTube APIs.
+            time.sleep(5)
+
+        _write_pending_removals(pending_removals)
+
+        logger.info("==> music-ingest complete. Run music-scan for local import and playlist generation.")
 
     except SystemExit:
         raise

--- a/pipeline/scan.py
+++ b/pipeline/scan.py
@@ -1,12 +1,13 @@
 """music-scan: import inbox → beets, refresh metadata, regenerate .m3u playlists,
 trigger Navidrome rescan, push Prometheus metrics.
 
-Called frequently (every 5 min by default) and also by music-ingest after a sync.
+Called frequently (every 5 min by default) and also after music-ingest completes.
 No Spotify or YouTube calls.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -24,6 +25,7 @@ QUARANTINE = Path("/root/Music/quarantine")
 PLAYLISTS = Path("/root/Music/playlists")
 INBOX = Path("/root/Music/inbox")
 LIBRARY_DB = Path("/root/.config/beets/library.db")
+PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
 
 
 def _count_quarantine() -> int:
@@ -48,6 +50,41 @@ def _quarantine_inbox_leftovers() -> int:
             f.rename(dest)
             moved += 1
     return moved
+
+
+def _process_pending_removals() -> int:
+    """Clear beets source tags for tracks removed from Spotify playlists by the fetch container.
+
+    Reads .pending-removals.json from the shared volume, processes each entry,
+    then deletes the file.  Returns the number of entries processed.
+    """
+    if not PENDING_REMOVALS.exists():
+        return 0
+
+    with open(PENDING_REMOVALS, encoding="utf-8") as fh:
+        entries = json.load(fh)
+
+    PENDING_REMOVALS.unlink()
+
+    if not entries:
+        return 0
+
+    logger.info("==> Processing %d pending removal(s) from fetch run...", len(entries))
+    with MusicLibrary(LIBRARY_DB) as lib:
+        for entry in entries:
+            title = entry.get("title", "")
+            artist = entry.get("artist", "")
+            source = entry.get("source", "")
+            found = lib.clear_source_tag(title=title, artist=artist, source=source)
+            if not found:
+                logger.warning(
+                    "  WARNING: not found in beets — may need manual cleanup: %s by %s (source=%s)",
+                    title,
+                    artist,
+                    source,
+                )
+
+    return len(entries)
 
 
 def _regen_playlists() -> None:
@@ -75,6 +112,9 @@ def run() -> None:
 
     try:
         logger.info("==> music-scan starting")
+
+        logger.info("==> Processing pending removals from fetch container...")
+        _process_pending_removals()
 
         quarantined_before = _count_quarantine()
 

--- a/pipeline/scan.py
+++ b/pipeline/scan.py
@@ -61,10 +61,14 @@ def _process_pending_removals() -> int:
     if not PENDING_REMOVALS.exists():
         return 0
 
-    with open(PENDING_REMOVALS, encoding="utf-8") as fh:
-        entries = json.load(fh)
-
+    content = PENDING_REMOVALS.read_text(encoding="utf-8")
     PENDING_REMOVALS.unlink()
+
+    try:
+        entries = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("Discarded malformed .pending-removals.json — skipping source-tag cleanup")
+        return 0
 
     if not entries:
         return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "music-pipeline"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = [
-    "beets==2.7.1",
-    "spotdl==4.4.3",
-    "pyacoustid==1.3.0",
-    "requests>=2.32",
-]
+dependencies = []
 
 [project.scripts]
 music-scan      = "pipeline.cli:scan"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
--r requirements.txt
+-r requirements-fetch.txt
+-r requirements-scan.txt
 pytest>=8.0

--- a/requirements-fetch.txt
+++ b/requirements-fetch.txt
@@ -1,0 +1,2 @@
+spotdl==4.4.3
+requests>=2.32

--- a/requirements-scan.txt
+++ b/requirements-scan.txt
@@ -1,4 +1,3 @@
 beets==2.7.1
-spotdl==4.4.3
 pyacoustid==1.3.0
 requests>=2.32

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,8 +1,11 @@
 """Tests for pipeline.ingest — pure-Python logic (no I/O, no external tools)."""
 
+import json
+from pathlib import Path
+
 import pytest
 
-from pipeline.ingest import classify_failure
+from pipeline.ingest import classify_failure, _collect_removals, _write_pending_removals
 from pipeline.spotdl_ops import find_track_in_snapshot
 
 
@@ -175,3 +178,102 @@ def test_budget_spans_playlists() -> None:
     # B2 and B3 are deferred
     assert "https://spotify.com/track/B2" not in written_b
     assert "https://spotify.com/track/B3" not in written_b
+
+
+# ---------------------------------------------------------------------------
+# _collect_removals
+# ---------------------------------------------------------------------------
+
+SNAPSHOT = [
+    {"url": "https://spotify.com/track/A", "name": "Song A", "artists": ["Artist 1"]},
+    {"url": "https://spotify.com/track/B", "name": "Song B", "artists": []},
+]
+
+
+def test_collect_removals_normal_case() -> None:
+    pending: list[dict] = []
+    _collect_removals(pending, {"https://spotify.com/track/A"}, SNAPSHOT, "my-playlist")
+    assert pending == [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+
+
+def test_collect_removals_url_not_in_snapshot() -> None:
+    """URL missing from snapshot → entry is skipped, no crash."""
+    pending: list[dict] = []
+    _collect_removals(pending, {"https://spotify.com/track/Z"}, SNAPSHOT, "my-playlist")
+    assert pending == []
+
+
+def test_collect_removals_empty_artists() -> None:
+    """artists=[] → artist field defaults to empty string."""
+    pending: list[dict] = []
+    _collect_removals(pending, {"https://spotify.com/track/B"}, SNAPSHOT, "my-playlist")
+    assert pending == [{"title": "Song B", "artist": "", "source": "my-playlist"}]
+
+
+def test_collect_removals_no_removed_urls() -> None:
+    pending: list[dict] = []
+    _collect_removals(pending, set(), SNAPSHOT, "my-playlist")
+    assert pending == []
+
+
+# ---------------------------------------------------------------------------
+# _write_pending_removals
+# ---------------------------------------------------------------------------
+
+
+def test_write_pending_removals_creates_file(tmp_path: Path) -> None:
+    import unittest.mock as mock
+    from pipeline import ingest
+
+    fake_path = tmp_path / ".pending-removals.json"
+    entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+
+    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
+        _write_pending_removals(entries)
+
+    assert fake_path.exists()
+    assert json.loads(fake_path.read_text()) == entries
+
+
+def test_write_pending_removals_appends_to_existing(tmp_path: Path) -> None:
+    """The append-safe merge is the key correctness guarantee of the cross-container handoff."""
+    import unittest.mock as mock
+    from pipeline import ingest
+
+    fake_path = tmp_path / ".pending-removals.json"
+    existing = [{"title": "Song A", "artist": "Artist 1", "source": "playlist-1"}]
+    fake_path.write_text(json.dumps(existing), encoding="utf-8")
+
+    new_entries = [{"title": "Song B", "artist": "Artist 2", "source": "playlist-2"}]
+    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
+        _write_pending_removals(new_entries)
+
+    result = json.loads(fake_path.read_text())
+    assert result == existing + new_entries
+
+
+def test_write_pending_removals_recovers_from_corrupt_file(tmp_path: Path) -> None:
+    """Corrupt existing file is discarded; new entries are still written."""
+    import unittest.mock as mock
+    from pipeline import ingest
+
+    fake_path = tmp_path / ".pending-removals.json"
+    fake_path.write_text("not valid json", encoding="utf-8")
+
+    entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
+        _write_pending_removals(entries)
+
+    assert json.loads(fake_path.read_text()) == entries
+
+
+def test_write_pending_removals_noop_when_empty(tmp_path: Path) -> None:
+    """No file created when there are no pending removals."""
+    import unittest.mock as mock
+    from pipeline import ingest
+
+    fake_path = tmp_path / ".pending-removals.json"
+    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
+        _write_pending_removals([])
+
+    assert not fake_path.exists()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -123,3 +123,63 @@ def test_process_pending_removals_empty_list(tmp_path: Path) -> None:
 
     assert count == 0
     assert not fake_path.exists()
+
+
+def test_process_pending_removals_malformed_json_deletes_file(tmp_path: Path) -> None:
+    """Malformed JSON must not leave the file in place (would break every future scan run)."""
+    from pipeline.scan import _process_pending_removals
+
+    fake_path = tmp_path / ".pending-removals.json"
+    fake_path.write_text("not valid json {{{{", encoding="utf-8")
+
+    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path):
+        count = _process_pending_removals()
+
+    assert count == 0
+    assert not fake_path.exists()  # file consumed even though JSON was invalid
+
+
+def test_process_pending_removals_multi_entry(tmp_path: Path) -> None:
+    from pipeline.scan import _process_pending_removals
+
+    fake_path = tmp_path / ".pending-removals.json"
+    entries = [
+        {"title": "Song A", "artist": "Artist 1", "source": "playlist-1"},
+        {"title": "Song B", "artist": "Artist 2", "source": "playlist-2"},
+    ]
+    fake_path.write_text(json.dumps(entries), encoding="utf-8")
+
+    mock_lib = mock.MagicMock()
+    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
+    mock_lib.__exit__ = mock.MagicMock(return_value=False)
+    mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
+
+    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+        count = _process_pending_removals()
+
+    assert count == 2
+    assert not fake_path.exists()
+    assert mock_lib.clear_source_tag.call_count == 2
+
+
+def test_process_pending_removals_file_deleted_before_processing(tmp_path: Path) -> None:
+    """File is unlinked before processing so an exception mid-processing doesn't re-block scans."""
+    from pipeline.scan import _process_pending_removals
+
+    fake_path = tmp_path / ".pending-removals.json"
+    entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+    fake_path.write_text(json.dumps(entries), encoding="utf-8")
+
+    mock_lib = mock.MagicMock()
+    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
+    mock_lib.__exit__ = mock.MagicMock(return_value=False)
+    mock_lib.clear_source_tag = mock.MagicMock(side_effect=RuntimeError("beets exploded"))
+
+    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+        with pytest.raises(RuntimeError):
+            _process_pending_removals()
+
+    # File was deleted before processing started — future scans are unblocked
+    assert not fake_path.exists()

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,7 +1,9 @@
 """Tests for pipeline.scan — pure-Python logic."""
 
+import json
 import os
 from pathlib import Path
+import unittest.mock as mock
 
 import pytest
 
@@ -55,7 +57,6 @@ def test_count_quarantine_with_files(tmp_path: Path) -> None:
 
 
 def test_quarantine_leftovers(tmp_path: Path) -> None:
-    import unittest.mock as mock
     from pipeline.scan import _quarantine_inbox_leftovers
 
     inbox = tmp_path / "inbox"
@@ -72,3 +73,53 @@ def test_quarantine_leftovers(tmp_path: Path) -> None:
     assert moved == 1
     assert (quarantine / "unmatched.m4a").exists()
     assert (inbox / "readme.txt").exists()  # non-audio left in place
+
+
+# ---------------------------------------------------------------------------
+# _process_pending_removals
+# ---------------------------------------------------------------------------
+
+
+def test_process_pending_removals_no_file(tmp_path: Path) -> None:
+    from pipeline.scan import _process_pending_removals
+
+    fake_path = tmp_path / ".pending-removals.json"
+    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path):
+        count = _process_pending_removals()
+    assert count == 0
+
+
+def test_process_pending_removals_reads_and_deletes(tmp_path: Path) -> None:
+    from pipeline.scan import _process_pending_removals
+
+    fake_path = tmp_path / ".pending-removals.json"
+    entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+    fake_path.write_text(json.dumps(entries), encoding="utf-8")
+
+    mock_lib = mock.MagicMock()
+    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
+    mock_lib.__exit__ = mock.MagicMock(return_value=False)
+    mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
+
+    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+        count = _process_pending_removals()
+
+    assert count == 1
+    assert not fake_path.exists()
+    mock_lib.clear_source_tag.assert_called_once_with(
+        title="Song A", artist="Artist 1", source="my-playlist"
+    )
+
+
+def test_process_pending_removals_empty_list(tmp_path: Path) -> None:
+    from pipeline.scan import _process_pending_removals
+
+    fake_path = tmp_path / ".pending-removals.json"
+    fake_path.write_text("[]", encoding="utf-8")
+
+    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path):
+        count = _process_pending_removals()
+
+    assert count == 0
+    assert not fake_path.exists()


### PR DESCRIPTION
## Plan
- [x] Split `requirements.txt` into `requirements-fetch.txt` (spotdl) and `requirements-scan.txt` (beets/pyacoustid)
- [x] Dockerfile: two independent build targets (`fetch`, `scan`); `dev` extends `scan`
- [x] `pyproject.toml`: empty `dependencies` so `pip install -e` only creates entry points
- [x] `ingest.py`: remove `scan.run()` call and beets coupling; write removed tracks to `.pending-removals.json` on the shared volume
- [x] `scan.py`: read and process `.pending-removals.json` at start of `run()`
- [x] `compose.yml`: split `pipeline` service into `fetch` and `scan` with appropriate volumes/env vars
- [x] `justfile`: `just fetch` / `just scan` / `just sync` (= fetch then scan)
- [x] `ci.yml`: build and push both images (`music-pipeline-fetch`, `music-pipeline-scan`)
- [x] `docs/`, `CLAUDE.md`: update service name references

## Summary
- The pipeline now runs as two containers: **fetch** (spotdl sync, no beets/ffmpeg) and **scan** (beets import, AcoustID, .m3u, Navidrome rescan)
- Removed-track info is passed between containers via `.pending-removals.json` on the shared `music-data` volume — fetch writes it, scan reads and deletes it
- CI builds and pushes two GHCR images: `music-pipeline-fetch:latest` and `music-pipeline-scan:latest`

## Test Plan
- [ ] CI passes (unit tests + both image builds + health checks)
- [ ] `just fetch` runs `music-ingest`, exits 0
- [ ] `just scan` runs `music-scan`, exits 0
- [ ] `just sync` runs fetch then scan end-to-end
- [ ] `docker images` shows distinct fetch and scan images