### PR TITLE
fix: handle .spotdl list format in snapshot diff

### DIFF
--- a/docs/manual-test-plan.md
+++ b/docs/manual-test-plan.md
@@ -117,7 +117,7 @@ docker compose cp track-a.mp3 scan:/root/Music/inbox/spotdl/test-playlist/
 
 **3. Create a minimal `.spotdl` state file:**
 ```bash
-docker compose run --rm scan sh -c 'echo "{\"songs\": []}" > /root/Music/inbox/spotdl/test-playlist.spotdl'
+docker compose run --rm scan sh -c 'echo "[]" > /root/Music/inbox/spotdl/test-playlist.spotdl'
 ```
 
 **4. Run a scan:**

--- a/fetch/pipeline/ingest.py
+++ b/fetch/pipeline/ingest.py
@@ -281,7 +281,7 @@ def run() -> None:
                 metrics.playlists_total += 1
                 continue
 
-            old_songs: list[dict] = sync_data.get("songs", [])
+            old_songs: list[dict] = sync_data if isinstance(sync_data, list) else []
 
             logger.info("==> Syncing playlist: %s", name)
             metrics.playlists_total += 1


### PR DESCRIPTION
## Summary
- `spotdl` writes `.spotdl` files as a plain JSON list (`[{...}, ...]`), not `{"songs": [{...}]}`.
- `ingest.py:284` called `.get("songs", [])` on the parsed JSON, which is a list → `AttributeError`.
- Also corrects the fake `.spotdl` example in the manual test plan.

## Root cause
The snapshot-diff logic in `_collect_removals` reads the pre-sync `.spotdl` file to match removed Spotify track URLs back to song metadata. The format assumption was wrong.

## Test plan
- [ ] CI passes
- [ ] After merge + image pull: `just sync` progresses past the snapshot-read step

🤖 Generated with [Claude Code](https://claude.com/claude-code)