### PR TITLE
fix: handle SpotifyClient singleton when save + sync run in same process

### DIFF
--- a/fetch/pipeline/spotdl_ops.py
+++ b/fetch/pipeline/spotdl_ops.py
@@ -39,16 +39,31 @@ def _make_downloader_settings(
 
 
 def _make_spotdl(settings: dict):
-    """Initialise and return a Spotdl instance."""
+    """Initialise and return a Spotdl instance.
+
+    SpotifyClient is a process-wide singleton in spotdl; calling Spotdl() a
+    second time raises SpotifyError("already been initialized").  When that
+    happens we skip re-init and just attach a fresh Downloader so the caller
+    gets an object with the requested output/format settings.
+    """
     from spotdl import Spotdl  # noqa: PLC0415
+    from spotdl.download.downloader import Downloader  # noqa: PLC0415
+    from spotdl.utils.spotify import SpotifyError  # noqa: PLC0415
 
     client_id = os.environ["SPOTIFY_CLIENT_ID"]
     client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
-    return Spotdl(
-        client_id=client_id,
-        client_secret=client_secret,
-        downloader_settings=settings,
-    )
+    try:
+        return Spotdl(
+            client_id=client_id,
+            client_secret=client_secret,
+            downloader_settings=settings,
+        )
+    except SpotifyError as exc:
+        if "already been initialized" not in str(exc):
+            raise
+        obj = object.__new__(Spotdl)
+        obj.downloader = Downloader(settings=settings)
+        return obj
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When a new playlist is provisioned, `save_playlist` and `sync_playlist` both call `_make_spotdl` in the same process
- spotdl's `SpotifyClient` is a process-wide singleton; calling `Spotdl()` a second time raises `SpotifyError("A spotify client has already been initialized")`
- Fix: catch that error in `_make_spotdl` and construct a bare `Spotdl` object with a fresh `Downloader` — skipping the SpotifyClient re-init
- This means any run that provisions a new playlist and then syncs it no longer crashes

## Test plan
- [ ] `just fetch` with a new playlist in `playlists.conf` completes without SpotifyError
- [ ] Both `save_playlist` (provision) and `sync_playlist` (download) succeed in the same run

🤖 Generated with [Claude Code](https://claude.com/claude-code)