### PR TITLE
chore: remove test-small playlist added during manual test run

### DIFF
--- a/config/playlists.conf
+++ b/config/playlists.conf
@@ -13,4 +13,3 @@
 # Example:
 # liked-songs   https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M
 # archived-mix  https://open.spotify.com/playlist/37i9dQZF1DXd9rLJfaAKCk  nosync
-test-small  https://open.spotify.com/playlist/4vz0skwrbDjQYJx1rxkctG


### PR DESCRIPTION
Removes the temporary test playlist entry added during Scenario 5 of the manual test run.