### PR TITLE
fix(beets): replace ignored: missing_tracks with max_rec: missing_tracks: strong

### DIFF
--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -17,9 +17,11 @@ match:
   # 0.05 accepts only very close MusicBrainz matches automatically.
   # Raise to 0.10 if too many valid tracks land in quarantine.
   strong_rec_thresh: 0.05
-  # Ignore missing-tracks penalty so spotdl downloads (one track at a time
-  # from multi-track albums) are not penalised for absent album tracks.
-  ignored: [missing_tracks]
+  # Allow spotdl downloads (one track at a time from multi-track albums) to
+  # still receive a strong recommendation despite missing album tracks, so
+  # quiet-mode auto-import accepts them.
+  max_rec:
+    missing_tracks: strong
 
 paths:
   default: $albumartist/$album/$track - $title


### PR DESCRIPTION
`ignored: missing_tracks` filters out album candidates that have missing
tracks entirely, which is the opposite of the intended behaviour. spotdl
downloads are always "missing" the rest of their album, so they were being
skipped rather than imported.

`max_rec: missing_tracks: strong` keeps those candidates visible and allows
them to receive a strong recommendation, so quiet-mode auto-import accepts
them as intended.

Ref: https://github.com/beetbox/beets/issues/3058

https://claude.ai/code/session_01S6nGrEtqBEehBPCE5Ke67G