### PR TITLE
feat: make just test-auth pass end-to-end

### DIFF
--- a/fetch/Dockerfile
+++ b/fetch/Dockerfile
@@ -1,9 +1,9 @@
 # fetch: spotdl sync, Spotify/YouTube network calls.
 FROM python:3.13-slim AS prod
 
-# ffmpeg required by spotdl (audio download and format handling)
+# ffmpeg required by spotdl; nodejs required by yt-dlp for JS challenge solving
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get install -y --no-install-recommends ffmpeg nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Python dependencies
@@ -19,7 +19,11 @@ RUN pip install --no-cache-dir -e /app
 RUN mkdir -p \
     /root/Music/inbox/spotdl \
     /root/.config/spotdl \
-    /root/.config/music-pipeline
+    /root/.config/music-pipeline \
+    /root/.config/yt-dlp
+
+# Use Node.js for EJS JS challenge solving (Deno is the default but not installed)
+RUN echo --js-runtimes node > /root/.config/yt-dlp/config
 
 CMD ["music-ingest"]
 

--- a/fetch/pipeline/spotdl_ops.py
+++ b/fetch/pipeline/spotdl_ops.py
@@ -32,6 +32,7 @@ def _make_downloader_settings(
         "sync_without_deleting": sync_without_deleting,
         "load_config": False,
         "threads": 4,
+        "yt_dlp_args": "--js-runtimes node",
     }
     if output_dir is not None:
         settings["output"] = str(output_dir)

--- a/fetch/requirements.txt
+++ b/fetch/requirements.txt
@@ -1,2 +1,3 @@
 spotdl==4.4.3
 requests>=2.32
+yt-dlp[default]

--- a/justfile
+++ b/justfile
@@ -8,14 +8,16 @@ test:
 # Run container integration tests against the current GHCR image (no auth needed)
 # Override the image with: SCAN_IMAGE=music-pipeline-scan:local just test-integration
 test-integration:
-    pip install -q -r tests/requirements.txt
-    pytest tests/ -m "not auth" -v
+    [ -d .venv ] || python3 -m venv .venv
+    .venv/bin/pip install -q -r tests/requirements.txt
+    .venv/bin/pytest tests/ -m "not auth" -v
 
 # Run auth-required integration tests (local only; requires Spotify credentials via 1Password)
 # Set TEST_PLAYLIST_URL to a small playlist before running: export TEST_PLAYLIST_URL=https://...
 test-auth:
-    pip install -q -r tests/requirements.txt
-    op run --env-file .env.tpl -- pytest tests/ -m auth -v
+    [ -d .venv ] || python3 -m venv .venv
+    .venv/bin/pip install -q -r tests/requirements.txt
+    op run --env-file .env.tpl -- .venv/bin/pytest tests/ -m auth -v
 
 # Install git hooks (run once after cloning)
 hooks:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,6 +29,7 @@ from conftest import (
     put_bytes,
     run_fetch,
     run_scan,
+    scan_binds_test,
 )
 
 pytestmark = pytest.mark.auth
@@ -48,7 +49,7 @@ _SKIP_REASON = "; ".join(_MISSING_PREREQS) + " — run via `just test-auth`"
 
 
 @pytest.mark.skipif(bool(_MISSING_PREREQS), reason=_SKIP_REASON)
-def test_full_ingest_spotify(docker_client, volumes):
+def test_full_ingest_spotify(docker_client, volumes, beets_asis_config):
     """End-to-end: spotdl sync → beets import → source tag → .m3u generation."""
     # Write a minimal .spotdl state with no songs so spotdl actually downloads
     put_bytes(
@@ -94,8 +95,8 @@ def test_full_ingest_spotify(docker_client, volumes):
         f"Fetch logs:\n{fetch_logs}"
     )
 
-    # Run scan
-    scan_exit, scan_logs = run_scan(docker_client, volumes)
+    # Run scan with asis config: this test validates auth and download, not MusicBrainz matching
+    scan_exit, scan_logs = run_scan(docker_client, volumes, binds=scan_binds_test(volumes, beets_asis_config))
     assert scan_exit == 0, f"music-scan exited {scan_exit}. Logs:\n{scan_logs}"
 
     # All downloaded tracks should be tagged with the correct source


### PR DESCRIPTION
## Summary

- **fetch container**: add `nodejs` + `yt-dlp[default]` to handle YouTube's JS challenges (EJS solver). Bake `/root/.config/yt-dlp/config` with `--js-runtimes node`; pass same flag via `yt_dlp_args` in spotdl downloader settings (spotdl uses `load_config: False` so the file is bypassed — `yt_dlp_args` is the correct override path).
- **justfile**: use `.venv` for `test-integration` and `test-auth` recipes to avoid externally-managed-environment errors on Debian host Python.
- **test_auth.py**: run scan with `beets_asis_config` (autotag=False) so the auth test validates Spotify auth + YouTube download without requiring a live MusicBrainz network call.

## Root cause (previously identified)

The old scan image registered the `music_pipeline` plugin on `import_task_choice`, which is never emitted in beets ASIS mode (`autotag: false`). The fix (`import_task_created`) was shipped in PR #35. This PR wires up the auth test to use ASIS mode so it exercises the correct code path without a MusicBrainz dependency.

## Test plan

- [x] `just test-auth` passes locally (1 passed, 68s) with `TEST_PLAYLIST_URL=https://open.spotify.com/playlist/4vz0skwrbDjQYJx1rxkctG`
- [ ] CI passes (non-auth integration tests via `just test-integration`)
- [ ] Verify fetch image builds cleanly in CI (nodejs layer + yt-dlp install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)