### PR TITLE
feat: raise match threshold to 0.10, add import name-check

### DIFF
--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -17,7 +17,7 @@ match:
   # Distance threshold: lower = stricter (0 = perfect match).
   # 0.05 accepts only very close MusicBrainz matches automatically.
   # Raise to 0.10 if too many valid tracks land in quarantine.
-  strong_rec_thresh: 0.05
+  strong_rec_thresh: 0.10
   # Allow spotdl downloads (one track at a time from multi-track albums) to
   # still receive a strong recommendation despite missing album tracks, so
   # quiet-mode auto-import accepts them.

--- a/scan/pipeline/library.py
+++ b/scan/pipeline/library.py
@@ -36,6 +36,14 @@ class MusicLibrary:
         """All items whose source flexible-attribute matches *source*."""
         return list(self._lib.items(f"source:{source}"))
 
+    def items_added_since(self, since: float) -> list[tuple[str, str]]:
+        """Return (title, artist) for items added to the library after *since* (Unix timestamp)."""
+        return [
+            (item.title or "", item.artist or item.albumartist or "")
+            for item in self._lib.items()
+            if (item.added or 0) >= since
+        ]
+
     def paths_by_source(self, source: str) -> list[Path]:
         """File paths for all items with the given source tag."""
         items = self.items_by_source(source)

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from pathlib import Path
 
@@ -19,12 +20,62 @@ from pipeline.process import run_beet_import, run_beet_update
 
 logger = logging.getLogger(__name__)
 
+AUDIO_EXTS = {".mp3", ".flac", ".ogg", ".opus", ".m4a", ".aac", ".wav", ".wma", ".aiff", ".ape", ".mpc"}
 SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
 QUARANTINE = Path("/root/Music/quarantine")
 PLAYLISTS = Path("/root/Music/playlists")
 INBOX = Path("/root/Music/inbox")
 LIBRARY_DB = Path("/root/.config/beets/library.db")
 PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
+
+
+_STOP_WORDS = frozenset({"the", "and", "for", "feat", "ft", "vs", "with", "a", "an", "of", "in", "on"})
+
+
+def _name_words(s: str) -> frozenset[str]:
+    """Normalise a track/filename string to a set of significant lowercase words."""
+    words = re.sub(r"[^\w\s]", " ", s.lower()).split()
+    return frozenset(w for w in words if len(w) > 2 and w not in _STOP_WORDS)
+
+
+def _snapshot_inbox(inbox: Path) -> list[str]:
+    """Return sorted list of audio filename stems currently in the inbox tree."""
+    return sorted(
+        f.stem for f in inbox.rglob("*")
+        if f.is_file() and f.suffix.lower() in AUDIO_EXTS
+    )
+
+
+def _check_import_names(inbox_stems: list[str], imported: list[tuple[str, str]]) -> None:
+    """Compare imported track names against the pre-import inbox snapshot.
+
+    Flags tracks whose title+artist shares less than 40% Jaccard word-overlap
+    with the closest matching inbox filename — a signal that beets may have
+    applied a wildly wrong match.
+    """
+    if not inbox_stems or not imported:
+        return
+
+    inbox_word_sets = [_name_words(s) for s in inbox_stems]
+
+    flagged = []
+    for title, artist in imported:
+        lib_words = _name_words(f"{title} {artist}")
+        if not lib_words:
+            continue
+        best = max(
+            (len(lib_words & iws) / max(len(lib_words | iws), 1) for iws in inbox_word_sets),
+            default=0.0,
+        )
+        if best < 0.4:
+            flagged.append((title, artist, best))
+
+    if flagged:
+        logger.warning("==> %d imported track(s) look unlike anything in the inbox (possible bad match):", len(flagged))
+        for title, artist, score in sorted(flagged, key=lambda x: x[2]):
+            logger.warning("  !! %s — %s  (best inbox overlap: %.0f%%)", title, artist, score * 100)
+    else:
+        logger.info("==> Name check OK: all %d imported tracks resemble their inbox source files", len(imported))
 
 
 def _count_quarantine() -> int:
@@ -40,11 +91,10 @@ def _quarantine_inbox_leftovers() -> int:
     files remain in the inbox.  We move them to quarantine for manual review.
     Returns the count of files moved.
     """
-    audio_exts = {".mp3", ".flac", ".ogg", ".opus", ".m4a", ".aac", ".wav", ".wma", ".aiff", ".ape", ".mpc"}
     QUARANTINE.mkdir(parents=True, exist_ok=True)
     moved = 0
     for f in INBOX.glob("*"):
-        if f.is_file() and f.suffix.lower() in audio_exts:
+        if f.is_file() and f.suffix.lower() in AUDIO_EXTS:
             dest = QUARANTINE / f.name
             f.rename(dest)
             moved += 1
@@ -154,7 +204,15 @@ def run() -> None:
         quarantined_before = _count_quarantine()
 
         logger.info("==> Importing from inbox...")
+        inbox_snapshot = _snapshot_inbox(INBOX)
+        logger.info("Inbox snapshot : %d audio file(s) queued for import", len(inbox_snapshot))
+        import_start = time.time()
         run_beet_import(INBOX)
+
+        with MusicLibrary(LIBRARY_DB) as lib:
+            imported = lib.items_added_since(import_start)
+        logger.info("Newly imported : %d track(s)", len(imported))
+        _check_import_names(inbox_snapshot, imported)
 
         logger.info("==> Quarantining skipped files...")
         moved = _quarantine_inbox_leftovers()

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -332,7 +332,7 @@ def test_name_words_normalises_correctly() -> None:
     from pipeline.scan import _name_words
 
     assert _name_words("DJ Koze - Pick Up") == {"koze", "pick"}
-    assert _name_words("Four Tet - Pyramid") == {"four", "pyramid"}
+    assert _name_words("Four Tet - Pyramid") == {"four", "tet", "pyramid"}
     # stop words and short words filtered
     assert "the" not in _name_words("The End of the World")
     assert "of" not in _name_words("Battle of Evermore")

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -307,6 +307,65 @@ def test_regen_playlists_empty_playlist_writes_empty_m3u(tmp_path: Path) -> None
     assert m3u.read_text(encoding="utf-8") == ""
 
 
+# ---------------------------------------------------------------------------
+# _snapshot_inbox, _name_words, _check_import_names
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_inbox_finds_audio_files(tmp_path: Path) -> None:
+    from pipeline.scan import _snapshot_inbox
+
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    (inbox / "sub").mkdir()
+    (inbox / "DJ Koze - Pick Up.m4a").touch()
+    (inbox / "sub" / "Four Tet - Pyramid.flac").touch()
+    (inbox / "readme.txt").touch()
+
+    with mock.patch("pipeline.scan.AUDIO_EXTS", {".m4a", ".flac"}):
+        stems = _snapshot_inbox(inbox)
+
+    assert stems == ["DJ Koze - Pick Up", "Four Tet - Pyramid"]
+
+
+def test_name_words_normalises_correctly() -> None:
+    from pipeline.scan import _name_words
+
+    assert _name_words("DJ Koze - Pick Up") == {"koze", "pick"}
+    assert _name_words("Four Tet - Pyramid") == {"four", "pyramid"}
+    # stop words and short words filtered
+    assert "the" not in _name_words("The End of the World")
+    assert "of" not in _name_words("Battle of Evermore")
+
+
+def test_check_import_names_no_flags_on_good_match(caplog: pytest.LogCaptureFixture) -> None:
+    from pipeline.scan import _check_import_names
+    import logging
+
+    inbox = ["DJ Koze - Pick Up", "Four Tet - Pyramid"]
+    imported = [("Pick Up", "DJ Koze"), ("Pyramid", "Four Tet")]
+
+    with caplog.at_level(logging.INFO, logger="pipeline.scan"):
+        _check_import_names(inbox, imported)
+
+    assert "Name check OK" in caplog.text
+    assert "!!" not in caplog.text
+
+
+def test_check_import_names_flags_bad_match(caplog: pytest.LogCaptureFixture) -> None:
+    from pipeline.scan import _check_import_names
+    import logging
+
+    inbox = ["DJ Koze - Pick Up"]
+    imported = [("Never Be Like You", "Flume")]  # completely different
+
+    with caplog.at_level(logging.WARNING, logger="pipeline.scan"):
+        _check_import_names(inbox, imported)
+
+    assert "!!" in caplog.text
+    assert "Never Be Like You" in caplog.text
+
+
 def test_process_pending_removals_file_deleted_before_processing(tmp_path: Path) -> None:
     """File is unlinked before processing so an exception mid-processing doesn't re-block scans."""
     from pipeline.scan import _process_pending_removals


### PR DESCRIPTION
## Plan
- [x] Raise `strong_rec_thresh` 0.05 → 0.10 — reduces skipped tracks for already-tagged imports where MusicBrainz + AcoustID distance lands in the 0.05–0.10 band
- [x] Snapshot inbox filenames before import, query newly-added beets items after, warn on any track whose title+artist shares <40% Jaccard word-overlap with the closest inbox filename (catches bad mis-matches early)
- [x] Extract `AUDIO_EXTS` to module-level constant shared by snapshot and quarantine helpers
- [x] Tests for `_snapshot_inbox`, `_name_words`, `_check_import_names`

## Test plan
- [ ] CI unit tests pass
- [ ] CI integration tests pass
- [ ] Image pushed to GHCR, `docker compose pull && just scan` runs cleanly
- [ ] Log shows `Inbox snapshot : N audio file(s)` and `Newly imported : N track(s)` lines
- [ ] Log shows `Name check OK` or flags any suspicious renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)