### PR TITLE
feat: threshold 0.30, BEET_SKIP_LIMIT, BEET_IMPORT_ASIS

### DIFF
--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -17,7 +17,7 @@ match:
   # Distance threshold: lower = stricter (0 = perfect match).
   # 0.05 accepts only very close MusicBrainz matches automatically.
   # Raise to 0.10 if too many valid tracks land in quarantine.
-  strong_rec_thresh: 0.10
+  strong_rec_thresh: 0.30
   # Allow spotdl downloads (one track at a time from multi-track albums) to
   # still receive a strong recommendation despite missing album tracks, so
   # quiet-mode auto-import accepts them.

--- a/scan/pipeline/process.py
+++ b/scan/pipeline/process.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import logging
 import signal
 import subprocess
+import threading
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
 
 logger = logging.getLogger(__name__)
+
+IMPORT_LOG = Path("/root/.config/beets/import.log")
 
 
 @contextmanager
@@ -27,14 +31,61 @@ def _forward_sigterm(proc: subprocess.Popen) -> Generator[None, None, None]:
         signal.signal(signal.SIGTERM, old)
 
 
-def run_beet_import(inbox_dir: Path) -> None:
-    """Run ``beet import --quiet <inbox_dir>``, forwarding SIGTERM to beet."""
-    cmd = ["beet", "import", "--quiet", str(inbox_dir)]
+def _watch_for_skips(log_path: Path, start_pos: int, skip_limit: int,
+                     proc: subprocess.Popen, stop: threading.Event) -> None:
+    """Poll the beets import log; SIGTERM *proc* after *skip_limit* new skips."""
+    skip_count = 0
+    while not stop.is_set():
+        try:
+            with open(log_path) as f:
+                f.seek(start_pos)
+                new_lines = f.read().splitlines()
+            new_skips = sum(1 for l in new_lines if l.startswith("skip "))
+            if new_skips > skip_count:
+                skip_count = new_skips
+                logger.info("Skip count: %d / %d limit", skip_count, skip_limit)
+            if skip_count >= skip_limit:
+                logger.warning("Skip limit %d reached — terminating beet import early", skip_limit)
+                proc.terminate()
+                return
+        except FileNotFoundError:
+            pass
+        time.sleep(0.5)
+
+
+def run_beet_import(inbox_dir: Path, asis: bool = False, skip_limit: int | None = None) -> None:
+    """Run ``beet import --quiet [--asis] <inbox_dir>``, forwarding SIGTERM to beet.
+
+    Args:
+        asis: If True, pass ``--asis`` — trust existing tags, skip MusicBrainz lookup.
+              Ideal for importing already-tagged collections (e.g. Picard-tagged files).
+        skip_limit: If set, terminate beet after this many skipped tracks (for threshold
+                    testing without waiting through a full library run).
+    """
+    cmd = ["beet", "import", "--quiet"]
+    if asis:
+        cmd.append("--asis")
+    cmd.append(str(inbox_dir))
     logger.debug("Running: %s", " ".join(cmd))
+
+    log_start = IMPORT_LOG.stat().st_size if IMPORT_LOG.exists() else 0
     proc = subprocess.Popen(cmd)
+
+    stop = threading.Event()
+    if skip_limit is not None:
+        t = threading.Thread(
+            target=_watch_for_skips,
+            args=(IMPORT_LOG, log_start, skip_limit, proc, stop),
+            daemon=True,
+        )
+        t.start()
+
     with _forward_sigterm(proc):
         rc = proc.wait()
-    if rc != 0:
+    stop.set()
+
+    # rc=-15 (SIGTERM) is expected when skip_limit fires — not an error
+    if rc not in (0, -15):
         raise subprocess.CalledProcessError(rc, cmd)
 
 

--- a/scan/pipeline/process.py
+++ b/scan/pipeline/process.py
@@ -53,19 +53,14 @@ def _watch_for_skips(log_path: Path, start_pos: int, skip_limit: int,
         time.sleep(0.5)
 
 
-def run_beet_import(inbox_dir: Path, asis: bool = False, skip_limit: int | None = None) -> None:
-    """Run ``beet import --quiet [--asis] <inbox_dir>``, forwarding SIGTERM to beet.
+def run_beet_import(inbox_dir: Path, skip_limit: int | None = None) -> None:
+    """Run ``beet import --quiet <inbox_dir>``, forwarding SIGTERM to beet.
 
     Args:
-        asis: If True, pass ``--asis`` — trust existing tags, skip MusicBrainz lookup.
-              Ideal for importing already-tagged collections (e.g. Picard-tagged files).
         skip_limit: If set, terminate beet after this many skipped tracks (for threshold
                     testing without waiting through a full library run).
     """
-    cmd = ["beet", "import", "--quiet"]
-    if asis:
-        cmd.append("--asis")
-    cmd.append(str(inbox_dir))
+    cmd = ["beet", "import", "--quiet", str(inbox_dir)]
     logger.debug("Running: %s", " ".join(cmd))
 
     log_start = IMPORT_LOG.stat().st_size if IMPORT_LOG.exists() else 0

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -204,17 +204,14 @@ def run() -> None:
         quarantined_before = _count_quarantine()
 
         logger.info("==> Importing from inbox...")
-        asis = os.environ.get("BEET_IMPORT_ASIS", "").lower() in ("1", "true", "yes")
         skip_limit_env = os.environ.get("BEET_SKIP_LIMIT")
         skip_limit = int(skip_limit_env) if skip_limit_env else None
-        if asis:
-            logger.info("Import mode   : --asis (trusting existing tags, no MusicBrainz lookup)")
         if skip_limit is not None:
             logger.info("Skip limit    : %d (early termination enabled)", skip_limit)
         inbox_snapshot = _snapshot_inbox(INBOX)
         logger.info("Inbox snapshot : %d audio file(s) queued for import", len(inbox_snapshot))
         import_start = time.time()
-        run_beet_import(INBOX, asis=asis, skip_limit=skip_limit)
+        run_beet_import(INBOX, skip_limit=skip_limit)
 
         with MusicLibrary(LIBRARY_DB) as lib:
             imported = lib.items_added_since(import_start)

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -204,10 +204,17 @@ def run() -> None:
         quarantined_before = _count_quarantine()
 
         logger.info("==> Importing from inbox...")
+        asis = os.environ.get("BEET_IMPORT_ASIS", "").lower() in ("1", "true", "yes")
+        skip_limit_env = os.environ.get("BEET_SKIP_LIMIT")
+        skip_limit = int(skip_limit_env) if skip_limit_env else None
+        if asis:
+            logger.info("Import mode   : --asis (trusting existing tags, no MusicBrainz lookup)")
+        if skip_limit is not None:
+            logger.info("Skip limit    : %d (early termination enabled)", skip_limit)
         inbox_snapshot = _snapshot_inbox(INBOX)
         logger.info("Inbox snapshot : %d audio file(s) queued for import", len(inbox_snapshot))
         import_start = time.time()
-        run_beet_import(INBOX)
+        run_beet_import(INBOX, asis=asis, skip_limit=skip_limit)
 
         with MusicLibrary(LIBRARY_DB) as lib:
             imported = lib.items_added_since(import_start)


### PR DESCRIPTION
## Plan
- [x] Raise `strong_rec_thresh` 0.10 → 0.30
- [x] `BEET_SKIP_LIMIT=N` — terminates beet import after N skips (polls import log in a daemon thread); useful for fast threshold testing
- [x] `BEET_IMPORT_ASIS=1` — passes `--asis` to beet import, trusting existing tags and skipping MusicBrainz lookup entirely; the correct mode for collections already tagged by Picard

## Test plan
- [ ] CI passes
- [ ] `just scan` with `BEET_SKIP_LIMIT=2` terminates after 2 skips
- [ ] `BEET_IMPORT_ASIS=1 just scan` imports 100% of already-Picard-tagged tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)