### PR TITLE
fix: add musicbrainz plugin to beets config

### DIFF
--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -17,7 +17,7 @@ match:
   # Distance threshold: lower = stricter (0 = perfect match).
   # 0.05 accepts only very close MusicBrainz matches automatically.
   # Raise to 0.10 if too many valid tracks land in quarantine.
-  strong_rec_thresh: 0.30
+  strong_rec_thresh: 0.10
   # Allow spotdl downloads (one track at a time from multi-track albums) to
   # still receive a strong recommendation despite missing album tracks, so
   # quiet-mode auto-import accepts them.

--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -32,7 +32,7 @@ paths:
 pluginpath:
   - /app/pipeline
 
-plugins: chroma fromfilename fetchart embedart scrub duplicates music_pipeline
+plugins: musicbrainz chroma fromfilename fetchart embedart scrub duplicates music_pipeline
 
 fetchart:
   auto: yes


### PR DESCRIPTION
## Summary

- Adds `musicbrainz` to the `plugins:` list in `config/beets/config.yaml`
- Lowers `strong_rec_thresh` back to 0.10 (was raised to 0.30 while debugging the missing plugin)

## Root cause

Beets 2.x extracted MusicBrainz support from core into an explicit plugin (`beetsplug/musicbrainz.py`). Without it declared in the config, `find_metadata_source_plugins()` never loads the MusicBrainz backend. As a result, both `track_for_id` (MBID lookup) and `item_candidates` (text search) return nothing silently — every file showed "Found 0 candidates" and was skipped, regardless of `strong_rec_thresh`. This was the root cause of the persistent quarantine issue observed during the Picard-tagged collection test.

With MusicBrainz now loading, 0.30 is too permissive (auto-imports at 70% confidence). 0.10 gives headroom for spotdl filenames while avoiding bad matches.

## Test plan

- [ ] Run `just scan` against the Picard-tagged collection — tracks that previously quarantined with "Found 0 candidates" should now match and import
- [ ] Confirm "Pictures of You" by The Cure imports at ~93% match score
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)