### PR TITLE
feat: quarantine --asis fallback pass

### DIFF
--- a/scan/pipeline/process.py
+++ b/scan/pipeline/process.py
@@ -53,14 +53,19 @@ def _watch_for_skips(log_path: Path, start_pos: int, skip_limit: int,
         time.sleep(0.5)
 
 
-def run_beet_import(inbox_dir: Path, skip_limit: int | None = None) -> None:
+def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool = False) -> None:
     """Run ``beet import --quiet <inbox_dir>``, forwarding SIGTERM to beet.
 
     Args:
         skip_limit: If set, terminate beet after this many skipped tracks (for threshold
                     testing without waiting through a full library run).
+        asis: If True, pass ``--asis`` to import using existing embedded tags without
+              MusicBrainz lookups.
     """
-    cmd = ["beet", "import", "--quiet", str(inbox_dir)]
+    cmd = ["beet", "import", "--quiet"]
+    if asis:
+        cmd.append("--asis")
+    cmd.append(str(inbox_dir))
     logger.debug("Running: %s", " ".join(cmd))
 
     log_start = IMPORT_LOG.stat().st_size if IMPORT_LOG.exists() else 0

--- a/scan/pipeline/process.py
+++ b/scan/pipeline/process.py
@@ -64,7 +64,7 @@ def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool =
     """
     cmd = ["beet", "import", "--quiet"]
     if asis:
-        cmd.append("--asis")
+        cmd.append("-A")
     cmd.append(str(inbox_dir))
     logger.debug("Running: %s", " ".join(cmd))
 

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 import time
 from pathlib import Path
 
@@ -174,6 +175,34 @@ def _process_pending_removals() -> int:
     return total
 
 
+_ASIS_REQUIRED_TAGS = ("title", "artist", "album", "tracknumber")
+
+
+def _move_asis_eligible(quarantine: Path, staging: Path) -> int:
+    """Move audio files from *quarantine* that have all required tags to *staging*.
+
+    Files missing title, artist, album, or tracknumber are left in quarantine.
+    Returns the count of files moved.
+    """
+    from mutagen import File as MutagenFile  # noqa: PLC0415 — beets dep, always available
+
+    moved = 0
+    for f in sorted(quarantine.rglob("*")):
+        if not f.is_file() or f.suffix.lower() not in AUDIO_EXTS:
+            continue
+        try:
+            tags = MutagenFile(f, easy=True)
+            if tags is None or not all(tags.get(k) for k in _ASIS_REQUIRED_TAGS):
+                continue
+        except Exception:
+            continue
+        dest = staging / f.relative_to(quarantine)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        f.rename(dest)
+        moved += 1
+    return moved
+
+
 def _regen_playlists() -> None:
     """Regenerate .m3u files for every .spotdl playlist."""
     PLAYLISTS.mkdir(parents=True, exist_ok=True)
@@ -227,7 +256,18 @@ def run() -> None:
 
         logger.info("==> Importing quarantine with existing tags (--asis)...")
         asis_start = time.time()
-        run_beet_import(QUARANTINE, asis=True)
+        with tempfile.TemporaryDirectory(prefix="asis-staging-") as staging_str:
+            staging = Path(staging_str)
+            staged = _move_asis_eligible(QUARANTINE, staging)
+            logger.info("Asis eligible : %d file(s) with sufficient tags", staged)
+            if staged:
+                run_beet_import(staging, asis=True)
+                # Return any files beet skipped (e.g. duplicates) to quarantine
+                for remaining in staging.rglob("*"):
+                    if remaining.is_file() and remaining.suffix.lower() in AUDIO_EXTS:
+                        dest = QUARANTINE / remaining.relative_to(staging)
+                        dest.parent.mkdir(parents=True, exist_ok=True)
+                        remaining.rename(dest)
         with MusicLibrary(LIBRARY_DB) as lib:
             asis_imported = lib.items_added_since(asis_start)
         logger.info("Asis pass     : %d track(s) imported from quarantine", len(asis_imported))

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -225,6 +225,13 @@ def run() -> None:
         logger.info("Quarantined : %d file(s) → %s", moved, QUARANTINE)
         logger.info("Log         : ~/.config/beets/import.log")
 
+        logger.info("==> Importing quarantine with existing tags (--asis)...")
+        asis_start = time.time()
+        run_beet_import(QUARANTINE, asis=True)
+        with MusicLibrary(LIBRARY_DB) as lib:
+            asis_imported = lib.items_added_since(asis_start)
+        logger.info("Asis pass     : %d track(s) imported from quarantine", len(asis_imported))
+
         logger.info("==> Refreshing library metadata...")
         run_beet_update()
 

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -384,7 +384,7 @@ def test_run_beet_import_asis_flag() -> None:
         run_beet_import(Path("/some/dir"), asis=True)
 
     cmd = mock_popen.call_args[0][0]
-    assert "--asis" in cmd
+    assert "-A" in cmd
     assert "--quiet" in cmd
 
 
@@ -400,7 +400,7 @@ def test_run_beet_import_no_asis_flag_by_default() -> None:
         run_beet_import(Path("/some/dir"))
 
     cmd = mock_popen.call_args[0][0]
-    assert "--asis" not in cmd
+    assert "-A" not in cmd
     assert "--quiet" in cmd
 
 

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -372,6 +372,64 @@ def test_check_import_names_flags_bad_match(caplog: pytest.LogCaptureFixture) ->
     assert "Never Be Like You" in caplog.text
 
 
+def _fake_tags(overrides: dict | None = None) -> dict:
+    base = {"title": ["Song"], "artist": ["Artist"], "album": ["Album"], "tracknumber": ["1"]}
+    if overrides:
+        base.update(overrides)
+    return base
+
+
+def test_move_asis_eligible_moves_fully_tagged_file(tmp_path: Path) -> None:
+    from pipeline.scan import _move_asis_eligible
+
+    quarantine = tmp_path / "quarantine"
+    quarantine.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (quarantine / "tagged.m4a").touch()
+
+    with mock.patch("mutagen.File", return_value=_fake_tags()):
+        count = _move_asis_eligible(quarantine, staging)
+
+    assert count == 1
+    assert (staging / "tagged.m4a").exists()
+    assert not (quarantine / "tagged.m4a").exists()
+
+
+def test_move_asis_eligible_leaves_untagged_file(tmp_path: Path) -> None:
+    from pipeline.scan import _move_asis_eligible
+
+    quarantine = tmp_path / "quarantine"
+    quarantine.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (quarantine / "noise.mp3").touch()
+
+    with mock.patch("mutagen.File", return_value={}):
+        count = _move_asis_eligible(quarantine, staging)
+
+    assert count == 0
+    assert (quarantine / "noise.mp3").exists()
+    assert not list(staging.iterdir())
+
+
+def test_move_asis_eligible_leaves_partially_tagged_file(tmp_path: Path) -> None:
+    from pipeline.scan import _move_asis_eligible
+
+    quarantine = tmp_path / "quarantine"
+    quarantine.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (quarantine / "partial.flac").touch()
+
+    # Has title and artist but missing album and tracknumber
+    with mock.patch("mutagen.File", return_value=_fake_tags({"album": None, "tracknumber": None})):
+        count = _move_asis_eligible(quarantine, staging)
+
+    assert count == 0
+    assert (quarantine / "partial.flac").exists()
+
+
 def test_run_beet_import_asis_flag() -> None:
     from pipeline.process import run_beet_import
     import unittest.mock as mock

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -372,6 +372,38 @@ def test_check_import_names_flags_bad_match(caplog: pytest.LogCaptureFixture) ->
     assert "Never Be Like You" in caplog.text
 
 
+def test_run_beet_import_asis_flag() -> None:
+    from pipeline.process import run_beet_import
+    import subprocess
+    import unittest.mock as mock
+
+    with mock.patch("subprocess.Popen") as mock_popen:
+        mock_proc = mock.MagicMock()
+        mock_proc.wait.return_value = 0
+        mock_popen.return_value = mock_proc
+        run_beet_import(Path("/some/dir"), asis=True)
+
+    cmd = mock_popen.call_args[0][0]
+    assert "--asis" in cmd
+    assert "--quiet" in cmd
+
+
+def test_run_beet_import_no_asis_flag_by_default() -> None:
+    from pipeline.process import run_beet_import
+    import subprocess
+    import unittest.mock as mock
+
+    with mock.patch("subprocess.Popen") as mock_popen:
+        mock_proc = mock.MagicMock()
+        mock_proc.wait.return_value = 0
+        mock_popen.return_value = mock_proc
+        run_beet_import(Path("/some/dir"))
+
+    cmd = mock_popen.call_args[0][0]
+    assert "--asis" not in cmd
+    assert "--quiet" in cmd
+
+
 def test_process_pending_removals_file_deleted_before_processing(tmp_path: Path) -> None:
     """File is unlinked before processing so an exception mid-processing doesn't re-block scans."""
     from pipeline.scan import _process_pending_removals

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -374,13 +374,13 @@ def test_check_import_names_flags_bad_match(caplog: pytest.LogCaptureFixture) ->
 
 def test_run_beet_import_asis_flag() -> None:
     from pipeline.process import run_beet_import
-    import subprocess
     import unittest.mock as mock
 
-    with mock.patch("subprocess.Popen") as mock_popen:
-        mock_proc = mock.MagicMock()
-        mock_proc.wait.return_value = 0
-        mock_popen.return_value = mock_proc
+    mock_proc = mock.MagicMock()
+    mock_proc.wait.return_value = 0
+    with mock.patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+         mock.patch("pipeline.process.IMPORT_LOG") as mock_log:
+        mock_log.exists.return_value = False
         run_beet_import(Path("/some/dir"), asis=True)
 
     cmd = mock_popen.call_args[0][0]
@@ -390,13 +390,13 @@ def test_run_beet_import_asis_flag() -> None:
 
 def test_run_beet_import_no_asis_flag_by_default() -> None:
     from pipeline.process import run_beet_import
-    import subprocess
     import unittest.mock as mock
 
-    with mock.patch("subprocess.Popen") as mock_popen:
-        mock_proc = mock.MagicMock()
-        mock_proc.wait.return_value = 0
-        mock_popen.return_value = mock_proc
+    mock_proc = mock.MagicMock()
+    mock_proc.wait.return_value = 0
+    with mock.patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+         mock.patch("pipeline.process.IMPORT_LOG") as mock_log:
+        mock_log.exists.return_value = False
         run_beet_import(Path("/some/dir"))
 
     cmd = mock_popen.call_args[0][0]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -49,8 +49,9 @@ def test_file_drop_known_track_imported_to_library(
     )
 
 
-def test_file_drop_noise_goes_to_quarantine(docker_client, volumes):
-    """Case B: a noise file that won't match MusicBrainz is moved to quarantine."""
+def test_file_drop_noise_rescued_by_asis_pass(docker_client, volumes):
+    """Case B: a noise file that won't match MusicBrainz is quarantined, then rescued
+    by the --asis fallback pass and imported to the library using its existing tags."""
     # Generate a short noise file inside the container using ffmpeg
     docker_client.containers.run(
         SCAN_IMAGE,
@@ -65,9 +66,15 @@ def test_file_drop_noise_goes_to_quarantine(docker_client, volumes):
     exit_code, logs = run_scan(docker_client, volumes)
     assert exit_code == 0, f"music-scan exited {exit_code}. Logs:\n{logs}"
 
+    # After the asis pass, the file should be out of quarantine
     quarantine_files = ls_in_volume(docker_client, volumes, "/root/Music/quarantine")
-    assert any("noise" in f for f in quarantine_files), (
-        f"noise.mp3 not found in quarantine. Quarantine contents: {quarantine_files}"
+    assert not any("noise" in f for f in quarantine_files), (
+        f"noise.mp3 still in quarantine after asis pass. Quarantine contents: {quarantine_files}"
+    )
+    # And imported into the library
+    library_files = ls_in_volume(docker_client, volumes, "/root/Music/library")
+    assert library_files, (
+        f"Library is empty after asis pass. Scan logs:\n{logs}"
     )
 
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -49,9 +49,9 @@ def test_file_drop_known_track_imported_to_library(
     )
 
 
-def test_file_drop_noise_rescued_by_asis_pass(docker_client, volumes):
-    """Case B: a noise file that won't match MusicBrainz is quarantined, then rescued
-    by the --asis fallback pass and imported to the library using its existing tags."""
+def test_file_drop_noise_goes_to_quarantine(docker_client, volumes):
+    """Case B: a tagless noise file that won't match MusicBrainz is moved to quarantine
+    and stays there — the asis pass skips files without sufficient embedded metadata."""
     # Generate a short noise file inside the container using ffmpeg
     docker_client.containers.run(
         SCAN_IMAGE,
@@ -66,15 +66,9 @@ def test_file_drop_noise_rescued_by_asis_pass(docker_client, volumes):
     exit_code, logs = run_scan(docker_client, volumes)
     assert exit_code == 0, f"music-scan exited {exit_code}. Logs:\n{logs}"
 
-    # After the asis pass, the file should be out of quarantine
     quarantine_files = ls_in_volume(docker_client, volumes, "/root/Music/quarantine")
-    assert not any("noise" in f for f in quarantine_files), (
-        f"noise.mp3 still in quarantine after asis pass. Quarantine contents: {quarantine_files}"
-    )
-    # And imported into the library
-    library_files = ls_in_volume(docker_client, volumes, "/root/Music/library")
-    assert library_files, (
-        f"Library is empty after asis pass. Scan logs:\n{logs}"
+    assert any("noise" in f for f in quarantine_files), (
+        f"noise.mp3 not found in quarantine. Quarantine contents: {quarantine_files}"
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `asis: bool = False` parameter to `run_beet_import()` in `process.py`
- Inserts a second `beet import --asis` pass on the quarantine directory after the normal MusicBrainz pass, so spotdl/Picard-tagged files are rescued using their embedded metadata
- Quarantine now only accumulates files with genuinely no usable metadata — a meaningful signal rather than a catch-all

## Plan
- [x] `process.py` — add `asis` param to `run_beet_import()`
- [x] `scan.py` — insert quarantine asis pass after `_quarantine_inbox_leftovers()`
- [x] `test_scan.py` — test `asis=True` builds correct command; negative test for default

## Test plan
- [ ] `just test` passes (CI)
- [ ] Manual: move quarantined files back to inbox, run `just scan`, confirm first pass imports MusicBrainz matches, second pass imports remainder from quarantine using existing tags, quarantine is empty after run, log shows "Asis pass : N track(s) imported from quarantine"

🤖 Generated with [Claude Code](https://claude.com/claude-code)