### PR TITLE
feat: cookies_expired gauge, track counters, and k8s PVC docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,23 @@ Two `CronJob` resources sharing two `PersistentVolumeClaim`s:
 
 ### PersistentVolumeClaims
 
-| PVC name | Mount path | Contents | Notes |
+| PVC name | Contents | Notes |
+|---|---|---|
+| `music-working` | `inbox/`, `quarantine/` | Ephemeral working data; shared between fetch and scan |
+| `music-library` | `library/`, `playlists/` | Permanent library; back this up |
+| `beets-data` | `library.db`, `import.log` | Small SQLite DB; back this up |
+
+Mounted with `subPath` so each PVC root maps to the correct sub-directory under `/root/Music`:
+
+| PVC | `subPath` | `mountPath` | Pods |
 |---|---|---|---|
-| `music-data` | `/root/Music` | Library, inbox, quarantine, playlists | Large; back up `library/` |
-| `beets-data` | `/root/.config/beets` | `library.db`, `import.log` | Small SQLite DB; back this up |
+| `music-working` | `inbox` | `/root/Music/inbox` | fetch, scan |
+| `music-working` | `quarantine` | `/root/Music/quarantine` | scan only |
+| `music-library` | `library` | `/root/Music/library` | scan only |
+| `music-library` | `playlists` | `/root/Music/playlists` | scan only |
+| `beets-data` | _(none)_ | `/root/.config/beets` | scan only |
+
+The fetch container only needs `music-working` (inbox mount). The scan container mounts all five.
 
 ### ConfigMaps
 

--- a/fetch/pipeline/ingest.py
+++ b/fetch/pipeline/ingest.py
@@ -302,8 +302,11 @@ def run() -> None:
                 )
                 metrics.success = False
                 metrics.failure_reason = reason
+                if reason == "auth_youtube":
+                    metrics.cookies_expired = True
                 raise
 
+            metrics.tracks_downloaded += tracks_sent
             if remaining is not None:
                 remaining -= tracks_sent
 

--- a/fetch/pipeline/metrics.py
+++ b/fetch/pipeline/metrics.py
@@ -38,6 +38,8 @@ class IngestMetrics:
     playlists_total: int = 0
     playlists_skipped: int = 0
     playlists_deferred: int = 0
+    tracks_downloaded: int = 0
+    cookies_expired: bool = False
     failure_reason: str = ""
 
     def push(self) -> None:
@@ -47,6 +49,8 @@ class IngestMetrics:
             _gauge("music_ingest_playlists_total", self.playlists_total),
             _gauge("music_ingest_playlists_skipped_total", self.playlists_skipped),
             _gauge("music_ingest_playlists_deferred_total", self.playlists_deferred),
+            _gauge("music_ingest_tracks_downloaded_total", self.tracks_downloaded),
+            _gauge("music_ingest_cookies_expired", int(self.cookies_expired)),
         ]
         if not self.success and self.failure_reason:
             lines.append(

--- a/fetch/tests/test_metrics.py
+++ b/fetch/tests/test_metrics.py
@@ -61,3 +61,32 @@ def test_push_job_label_ingest(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("pipeline.metrics._push", lambda body, job: jobs.append(job))
     IngestMetrics().push()
     assert jobs == ["music_ingest"]
+
+
+def test_ingest_metrics_tracks_downloaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    pushed: list[str] = []
+    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+
+    m = IngestMetrics(tracks_downloaded=42)
+    m.push()
+
+    assert "music_ingest_tracks_downloaded_total 42" in pushed[0]
+
+
+def test_ingest_metrics_cookies_expired_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    pushed: list[str] = []
+    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+
+    m = IngestMetrics(cookies_expired=True)
+    m.push()
+
+    assert "music_ingest_cookies_expired 1" in pushed[0]
+
+
+def test_ingest_metrics_cookies_expired_false_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    pushed: list[str] = []
+    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+
+    IngestMetrics().push()
+
+    assert "music_ingest_cookies_expired 0" in pushed[0]

--- a/scan/pipeline/metrics.py
+++ b/scan/pipeline/metrics.py
@@ -36,6 +36,8 @@ class ScanMetrics:
     success: bool = True
     duration_seconds: int = 0
     quarantined_tracks: int = 0
+    tracks_imported: int = 0
+    tracks_removed: int = 0
     failure_reason: str = ""
 
     def push(self) -> None:
@@ -43,6 +45,8 @@ class ScanMetrics:
             _gauge("music_scan_last_run_success", int(self.success)),
             _gauge("music_scan_duration_seconds", self.duration_seconds),
             _gauge("music_scan_quarantined_tracks_total", self.quarantined_tracks),
+            _gauge("music_scan_tracks_imported_total", self.tracks_imported),
+            _gauge("music_scan_tracks_removed_total", self.tracks_removed),
         ]
         if not self.success and self.failure_reason:
             lines.append(

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -231,7 +231,7 @@ def run() -> None:
         logger.info("==> music-scan starting")
 
         logger.info("==> Processing pending removals from fetch container...")
-        _process_pending_removals()
+        metrics.tracks_removed = _process_pending_removals()
 
         quarantined_before = _count_quarantine()
 
@@ -272,6 +272,7 @@ def run() -> None:
         with MusicLibrary(LIBRARY_DB) as lib:
             asis_imported = lib.items_added_since(asis_start)
         logger.info("Asis pass     : %d track(s) imported from quarantine", len(asis_imported))
+        metrics.tracks_imported = len(imported) + len(asis_imported)
 
         logger.info("==> Refreshing library metadata...")
         run_beet_update()

--- a/scan/tests/test_metrics.py
+++ b/scan/tests/test_metrics.py
@@ -61,3 +61,26 @@ def test_push_job_label_scan(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("pipeline.metrics._push", lambda body, job: jobs.append(job))
     ScanMetrics().push()
     assert jobs == ["music_scan"]
+
+
+def test_scan_metrics_tracks_imported(monkeypatch: pytest.MonkeyPatch) -> None:
+    pushed: list[str] = []
+    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+
+    m = ScanMetrics(tracks_imported=15, tracks_removed=3)
+    m.push()
+
+    body = pushed[0]
+    assert "music_scan_tracks_imported_total 15" in body
+    assert "music_scan_tracks_removed_total 3" in body
+
+
+def test_scan_metrics_track_counters_default_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    pushed: list[str] = []
+    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+
+    ScanMetrics().push()
+
+    body = pushed[0]
+    assert "music_scan_tracks_imported_total 0" in body
+    assert "music_scan_tracks_removed_total 0" in body


### PR DESCRIPTION
## Summary

- **`music_ingest_cookies_expired` gauge** — emits `1` when a spotdl sync fails with `auth_youtube`, enabling a clean `music_ingest_cookies_expired == 1` PrometheusRule expression (no label-selector workaround needed)
- **`music_ingest_tracks_downloaded_total`** — accumulates `tracks_sent` from each playlist sync loop iteration
- **`music_scan_tracks_imported_total` / `music_scan_tracks_removed_total`** — wired from `items_added_since()` (standard + asis pass) and `_process_pending_removals()` return value respectively
- **README k8s PVC table** — replaces single `music-data` PVC with `music-working` (`inbox/`, `quarantine/`) and `music-library` (`library/`, `playlists/`); adds `subPath` mount table with per-pod assignments

Addresses the feature gap and documentation gap flagged in homelab issue #423.

## Test plan

- [ ] `just test` passes (new metric field tests added to both `fetch/tests/test_metrics.py` and `scan/tests/test_metrics.py`)
- [ ] Manual: run `just fetch` with `PUSHGATEWAY_URL` set; confirm `music_ingest_tracks_downloaded_total` and `music_ingest_cookies_expired` appear at `/metrics`
- [ ] Manual: run `just scan` with `PUSHGATEWAY_URL` set; confirm `music_scan_tracks_imported_total` and `music_scan_tracks_removed_total` appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)