### PR TITLE
fix: add trailing newline to Pushgateway metric body

### DIFF
--- a/fetch/pipeline/metrics.py
+++ b/fetch/pipeline/metrics.py
@@ -25,7 +25,7 @@ def _push(body: str, job: str) -> None:
         return
     endpoint = f"{url.rstrip('/')}/metrics/job/{job}"
     try:
-        resp = requests.post(endpoint, data=body.encode(), timeout=10)
+        resp = requests.post(endpoint, data=(body + "\n").encode(), timeout=10)
         resp.raise_for_status()
     except requests.RequestException as exc:
         logger.warning("Failed to push metrics to %s: %s", endpoint, exc)

--- a/scan/pipeline/metrics.py
+++ b/scan/pipeline/metrics.py
@@ -25,7 +25,7 @@ def _push(body: str, job: str) -> None:
         return
     endpoint = f"{url.rstrip('/')}/metrics/job/{job}"
     try:
-        resp = requests.post(endpoint, data=body.encode(), timeout=10)
+        resp = requests.post(endpoint, data=(body + "\n").encode(), timeout=10)
         resp.raise_for_status()
     except requests.RequestException as exc:
         logger.warning("Failed to push metrics to %s: %s", endpoint, exc)


### PR DESCRIPTION
## Summary
- Prometheus text format requires a trailing `\n` on the final line; without it Pushgateway returns 400 Bad Request
- Fixes metrics push in both `fetch/pipeline/metrics.py` and `scan/pipeline/metrics.py`

## Test plan
- [ ] Verify `music-scan` and `music-ingest` jobs push metrics successfully (no 400 in logs)
- [ ] Check Pushgateway UI shows `music_scan_*` and `music_ingest_*` metrics after next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)