### PR TITLE
feat: trigger Navidrome library rescan after scan completes

### DIFF
--- a/scan/pipeline/navidrome.py
+++ b/scan/pipeline/navidrome.py
@@ -1,0 +1,49 @@
+"""Notify Navidrome to trigger a library rescan via the Subsonic API."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def trigger_scan() -> None:
+    """POST a startScan request to Navidrome if NAVIDROME_URL is configured.
+
+    Reads NAVIDROME_URL, NAVIDROME_USER, and NAVIDROME_PASSWORD from the
+    environment. If any are absent, logs a debug message and returns silently —
+    the caller does not need to guard against a missing configuration.
+    """
+    url = os.environ.get("NAVIDROME_URL", "")
+    user = os.environ.get("NAVIDROME_USER", "")
+    password = os.environ.get("NAVIDROME_PASSWORD", "")
+
+    if not url:
+        return
+
+    if not user or not password:
+        logger.warning("NAVIDROME_URL is set but NAVIDROME_USER or NAVIDROME_PASSWORD is missing — skipping rescan")
+        return
+
+    endpoint = f"{url.rstrip('/')}/rest/startScan.view"
+    params = {
+        "u": user,
+        "p": password,
+        "v": "1.8.0",
+        "c": "music-pipeline",
+        "f": "json",
+    }
+    try:
+        resp = requests.get(endpoint, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        status = data.get("subsonic-response", {}).get("status")
+        if status != "ok":
+            logger.warning("Navidrome rescan returned non-ok status: %s", data)
+        else:
+            logger.info("==> Navidrome library rescan triggered")
+    except requests.RequestException as exc:
+        logger.warning("Failed to trigger Navidrome rescan: %s", exc)

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from pipeline.library import MusicLibrary
 from pipeline.metrics import ScanMetrics
+from pipeline.navidrome import trigger_scan
 from pipeline.process import run_beet_import, run_beet_update
 
 logger = logging.getLogger(__name__)
@@ -284,6 +285,7 @@ def run() -> None:
         metrics.quarantined_tracks = max(0, quarantined_after - quarantined_before)
 
         logger.info("==> music-scan complete")
+        trigger_scan()
 
     except Exception:
         metrics.success = False

--- a/scan/tests/test_navidrome.py
+++ b/scan/tests/test_navidrome.py
@@ -1,0 +1,133 @@
+"""Tests for pipeline.navidrome.trigger_scan()."""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pytest
+import requests
+
+
+def _make_subsonic_response(status: str = "ok") -> dict:
+    return {"subsonic-response": {"status": status, "version": "1.8.0"}}
+
+
+@pytest.fixture(autouse=True)
+def clear_navidrome_env(monkeypatch):
+    """Ensure Navidrome env vars are absent by default in every test."""
+    monkeypatch.delenv("NAVIDROME_URL", raising=False)
+    monkeypatch.delenv("NAVIDROME_USER", raising=False)
+    monkeypatch.delenv("NAVIDROME_PASSWORD", raising=False)
+
+
+def test_no_url_skips_http_call():
+    """When NAVIDROME_URL is unset, no HTTP request is made."""
+    with mock.patch("pipeline.navidrome.requests.get") as mock_get:
+        from pipeline.navidrome import trigger_scan
+        trigger_scan()
+    mock_get.assert_not_called()
+
+
+def test_url_without_credentials_logs_warning(monkeypatch, caplog):
+    """When URL is set but credentials are missing, log a warning and skip."""
+    monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
+
+    with mock.patch("pipeline.navidrome.requests.get") as mock_get:
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
+            from pipeline.navidrome import trigger_scan
+            trigger_scan()
+
+    mock_get.assert_not_called()
+    assert "NAVIDROME_USER or NAVIDROME_PASSWORD is missing" in caplog.text
+
+
+def test_url_with_only_user_logs_warning(monkeypatch, caplog):
+    """When URL and user are set but password is missing, still warns."""
+    monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
+    monkeypatch.setenv("NAVIDROME_USER", "admin")
+
+    with mock.patch("pipeline.navidrome.requests.get") as mock_get:
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
+            from pipeline.navidrome import trigger_scan
+            trigger_scan()
+
+    mock_get.assert_not_called()
+    assert "NAVIDROME_USER or NAVIDROME_PASSWORD is missing" in caplog.text
+
+
+def test_successful_scan_logs_info(monkeypatch, caplog):
+    """Happy path: Subsonic returns ok → info logged, correct endpoint called."""
+    monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
+    monkeypatch.setenv("NAVIDROME_USER", "admin")
+    monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
+
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = _make_subsonic_response("ok")
+
+    with mock.patch("pipeline.navidrome.requests.get", return_value=mock_resp) as mock_get:
+        import logging
+        with caplog.at_level(logging.INFO, logger="pipeline.navidrome"):
+            from pipeline.navidrome import trigger_scan
+            trigger_scan()
+
+    mock_get.assert_called_once()
+    call_kwargs = mock_get.call_args
+    assert call_kwargs[0][0] == "http://navidrome.example.com/rest/startScan.view"
+    assert call_kwargs[1]["params"]["u"] == "admin"
+    assert call_kwargs[1]["params"]["f"] == "json"
+    assert "Navidrome library rescan triggered" in caplog.text
+
+
+def test_trailing_slash_in_url_is_normalized(monkeypatch):
+    """A trailing slash in NAVIDROME_URL must not produce a double slash."""
+    monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com/")
+    monkeypatch.setenv("NAVIDROME_USER", "admin")
+    monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
+
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = _make_subsonic_response("ok")
+
+    with mock.patch("pipeline.navidrome.requests.get", return_value=mock_resp) as mock_get:
+        from pipeline.navidrome import trigger_scan
+        trigger_scan()
+
+    url_called = mock_get.call_args[0][0]
+    assert "//" not in url_called.replace("http://", "")
+
+
+def test_non_ok_subsonic_status_logs_warning(monkeypatch, caplog):
+    """When Subsonic returns a non-ok status, a warning is logged."""
+    monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
+    monkeypatch.setenv("NAVIDROME_USER", "admin")
+    monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
+
+    mock_resp = mock.Mock()
+    mock_resp.json.return_value = _make_subsonic_response("failed")
+
+    with mock.patch("pipeline.navidrome.requests.get", return_value=mock_resp):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
+            from pipeline.navidrome import trigger_scan
+            trigger_scan()
+
+    assert "non-ok status" in caplog.text
+
+
+def test_http_error_logs_warning(monkeypatch, caplog):
+    """When requests raises a RequestException, a warning is logged (not raised)."""
+    monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
+    monkeypatch.setenv("NAVIDROME_USER", "admin")
+    monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
+
+    with mock.patch(
+        "pipeline.navidrome.requests.get",
+        side_effect=requests.ConnectionError("connection refused"),
+    ):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
+            from pipeline.navidrome import trigger_scan
+            trigger_scan()
+
+    assert "Failed to trigger Navidrome rescan" in caplog.text


### PR DESCRIPTION
## Summary

- Adds `scan/pipeline/navidrome.py` with a `trigger_scan()` function that calls Navidrome's Subsonic `startScan.view` endpoint
- Calls `trigger_scan()` at the end of a successful `run()` in `scan.py`
- Configured via `NAVIDROME_URL`, `NAVIDROME_USER`, `NAVIDROME_PASSWORD` env vars — silently skipped if unset (same pattern as `PUSHGATEWAY_URL`)

## Why

NFS mounts don't support inotify, so Navidrome's filesystem watcher never fires when beets imports new tracks. Without a periodic scan schedule, Navidrome only rescans at startup. This makes the scan job the natural trigger point.

## Test plan

- [ ] Unit tests for `trigger_scan()`: env vars absent → no HTTP call; missing credentials → warning logged; non-ok Subsonic response → warning logged; successful call → info logged
- [ ] Deploy to k8s with `NAVIDROME_URL`/credentials set; run `music-scan` manually; verify Navidrome picks up new tracks without a manual UI scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)