### PR TITLE
fix: write empty songs stub on provisioning so first sync downloads all tracks

### DIFF
--- a/fetch/pipeline/ingest.py
+++ b/fetch/pipeline/ingest.py
@@ -106,7 +106,7 @@ def _reconcile_playlists() -> list[str]:
         if not spotdl_file.exists():
             logger.info("==> Provisioning new playlist: %s", pl.name)
             output_dir.mkdir(parents=True, exist_ok=True)
-            save_playlist(url=pl.url, spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=COOKIE_FILE)
+            save_playlist(url=pl.url, spotdl_file=spotdl_file)
 
         if pl.nosync:
             if not nosync_file.exists():

--- a/fetch/pipeline/spotdl_ops.py
+++ b/fetch/pipeline/spotdl_ops.py
@@ -70,26 +70,22 @@ def _make_spotdl(settings: dict):
 # ---------------------------------------------------------------------------
 
 
-def save_playlist(url: str, spotdl_file: Path, output_dir: Path, cookie_file: Path) -> None:
-    """Fetch a Spotify playlist's metadata and write a .spotdl sync file.
+def save_playlist(url: str, spotdl_file: Path) -> None:
+    """Write a stub .spotdl sync file for a newly provisioned playlist.
 
-    Writes the sync dict format (type/query/songs) that sync_playlist expects,
-    rather than spotdl's native save format (a plain list).
+    Writes an empty songs list so the first sync treats all tracks as new and
+    downloads them.  The snapshot is populated by sync_playlist() as tracks are
+    downloaded; it records what has been downloaded, not what Spotify reports.
     Idempotent: callers should check whether the file already exists before calling.
     """
-    spotdl_obj = _make_spotdl(
-        _make_downloader_settings(cookie_file=cookie_file, output_dir=output_dir)
-    )
-    logger.info("Fetching playlist metadata for %s", url)
-    songs = spotdl_obj.search([url])
     sync_data = {
         "type": "sync",
         "query": [url],
-        "songs": [s.json for s in songs],
+        "songs": [],
     }
     with open(spotdl_file, "w", encoding="utf-8") as fh:
         json.dump(sync_data, fh, indent=4, ensure_ascii=False)
-    logger.info("Saved %d song(s) to %s", len(songs), spotdl_file)
+    logger.info("Provisioned stub .spotdl file for %s", spotdl_file.stem)
 
 
 def sync_playlist(

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -386,7 +386,6 @@ def test_reconcile_provisions_new_playlist(tmp_path: Path) -> None:
     call_kwargs = mock_save.call_args[1]
     assert call_kwargs["url"] == "https://open.spotify.com/playlist/abc"
     assert call_kwargs["spotdl_file"] == spotdl_dir / "my-playlist.spotdl"
-    assert call_kwargs["output_dir"] == spotdl_dir / "my-playlist"
     assert result == []
 
 

--- a/fetch/tests/test_spotdl_ops.py
+++ b/fetch/tests/test_spotdl_ops.py
@@ -1,0 +1,163 @@
+"""Tests for pipeline.spotdl_ops — pure-Python logic (no spotdl process, no network)."""
+
+from __future__ import annotations
+
+import json
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+from pipeline.spotdl_ops import save_playlist, sync_playlist
+
+
+# ---------------------------------------------------------------------------
+# save_playlist
+# ---------------------------------------------------------------------------
+
+
+def test_save_playlist_writes_stub_with_empty_songs(tmp_path: Path) -> None:
+    """save_playlist writes a valid sync stub with no songs."""
+    spotdl_file = tmp_path / "mypl.spotdl"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    assert spotdl_file.exists()
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    assert data["type"] == "sync"
+    assert data["query"] == ["https://open.spotify.com/playlist/abc"]
+    assert data["songs"] == []
+
+
+def test_save_playlist_overwrites_existing_file(tmp_path: Path) -> None:
+    """save_playlist overwrites an existing file without error."""
+    spotdl_file = tmp_path / "mypl.spotdl"
+    spotdl_file.write_text("old content", encoding="utf-8")
+
+    save_playlist(url="https://open.spotify.com/playlist/xyz", spotdl_file=spotdl_file)
+
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    assert data["query"] == ["https://open.spotify.com/playlist/xyz"]
+    assert data["songs"] == []
+
+
+# ---------------------------------------------------------------------------
+# sync_playlist — regression: first sync after provisioning downloads all songs
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_song(url: str, title: str = "Song") -> mock.Mock:
+    song = mock.Mock()
+    song.url = url
+    song.json = {"url": url, "name": title, "artists": ["Artist"]}
+    return song
+
+
+def test_sync_playlist_after_stub_downloads_all_songs(tmp_path: Path) -> None:
+    """Regression: after save_playlist writes a stub, sync downloads all songs.
+
+    This is the exact scenario from issue #46: provisioning creates an empty
+    snapshot, so the first sync must treat all Spotify songs as 'truly new'.
+    """
+    spotdl_file = tmp_path / "mypl.spotdl"
+    output_dir = tmp_path / "mypl"
+    output_dir.mkdir()
+    cookie_file = tmp_path / "cookies.txt"
+
+    # Simulate provisioning: write the stub
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    # Spotify returns 5 tracks on the first sync
+    songs = [_make_mock_song(f"https://open.spotify.com/track/{i}") for i in range(5)]
+
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = songs
+
+    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        removed_urls, tracks_sent = sync_playlist(
+            spotdl_file=spotdl_file,
+            output_dir=output_dir,
+            cookie_file=cookie_file,
+        )
+
+    # All 5 songs should be sent to download — none were in the empty snapshot
+    assert tracks_sent == 5
+    mock_spotdl.download_songs.assert_called_once()
+    downloaded = mock_spotdl.download_songs.call_args[0][0]
+    assert len(downloaded) == 5
+    assert removed_urls == set()
+
+
+def test_sync_playlist_second_run_skips_known_songs(tmp_path: Path) -> None:
+    """On subsequent syncs, songs already in the snapshot are not re-downloaded."""
+    spotdl_file = tmp_path / "mypl.spotdl"
+    output_dir = tmp_path / "mypl"
+    output_dir.mkdir()
+    cookie_file = tmp_path / "cookies.txt"
+
+    # Simulate a snapshot with 3 previously downloaded songs
+    existing_songs = [_make_mock_song(f"https://open.spotify.com/track/{i}") for i in range(3)]
+    spotdl_file.write_text(
+        json.dumps({
+            "type": "sync",
+            "query": ["https://open.spotify.com/playlist/abc"],
+            "songs": [s.json for s in existing_songs],
+        }),
+        encoding="utf-8",
+    )
+
+    # Spotify now returns 5 songs: the 3 known + 2 new
+    new_songs = [_make_mock_song(f"https://open.spotify.com/track/{i}") for i in range(5)]
+
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = new_songs
+
+    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        removed_urls, tracks_sent = sync_playlist(
+            spotdl_file=spotdl_file,
+            output_dir=output_dir,
+            cookie_file=cookie_file,
+        )
+
+    # Only the 2 new songs should be downloaded
+    assert tracks_sent == 2
+    downloaded = mock_spotdl.download_songs.call_args[0][0]
+    downloaded_urls = {s.url for s in downloaded}
+    assert downloaded_urls == {
+        "https://open.spotify.com/track/3",
+        "https://open.spotify.com/track/4",
+    }
+    assert removed_urls == set()
+
+
+def test_sync_playlist_detects_removed_tracks(tmp_path: Path) -> None:
+    """Tracks present in the old snapshot but absent from Spotify are flagged as removed."""
+    spotdl_file = tmp_path / "mypl.spotdl"
+    output_dir = tmp_path / "mypl"
+    output_dir.mkdir()
+    cookie_file = tmp_path / "cookies.txt"
+
+    spotdl_file.write_text(
+        json.dumps({
+            "type": "sync",
+            "query": ["https://open.spotify.com/playlist/abc"],
+            "songs": [
+                {"url": "https://open.spotify.com/track/A", "name": "Track A", "artists": []},
+                {"url": "https://open.spotify.com/track/B", "name": "Track B", "artists": []},
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    # Spotify no longer has track B
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [_make_mock_song("https://open.spotify.com/track/A")]
+
+    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        removed_urls, tracks_sent = sync_playlist(
+            spotdl_file=spotdl_file,
+            output_dir=output_dir,
+            cookie_file=cookie_file,
+        )
+
+    assert removed_urls == {"https://open.spotify.com/track/B"}
+    assert tracks_sent == 0  # A was already known; nothing new to download


### PR DESCRIPTION
## Summary

- Fixes #46: on first run after provisioning a new playlist, `music-ingest` completed instantly without downloading any tracks
- Root cause: `save_playlist()` called `spotdl.search()` and wrote the results as `old_urls`; `sync_playlist()` then excluded those URLs as "already downloaded," leaving `truly_new = []`
- Fix: `save_playlist()` now writes a stub `.spotdl` file with `songs: []` — the snapshot records what has been downloaded, not what Spotify reports at provisioning time

## Changes

- `fetch/pipeline/spotdl_ops.py`: `save_playlist()` simplified to write a stub; no Spotify API call during provisioning
- `fetch/pipeline/ingest.py`: call site updated (removed now-unnecessary `output_dir` and `cookie_file` kwargs)
- `fetch/tests/test_spotdl_ops.py` (new): regression test verifying first sync downloads all songs, plus steady-state and removal-detection cases

## Test plan

- [ ] CI passes
- [ ] Deploy and add a new playlist to `playlists.conf`; run `music-ingest`; verify tracks are downloaded on first sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)