### PR TITLE
feat: trigger Navidrome rescan after scan

### DIFF
--- a/.claude/hookify.docker-run-inspection.local.md
+++ b/.claude/hookify.docker-run-inspection.local.md
@@ -1,0 +1,15 @@
+---
+name: warn-docker-run-inspection
+enabled: true
+event: bash
+pattern: docker\s+run\b
+action: warn
+---
+
+**Before using `docker run` to inspect container internals:**
+
+- Check if the source file exists on the host first (e.g. in a cloned repo or installed package path)
+- Use `context7` docs to look up library internals without running a container
+- Reserve `docker run` for cases where the *container environment itself* is what you need to inspect (not just reading a source file)
+
+This avoids unnecessary warden approval prompts and is faster than spinning up a container for a grep.

--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -285,7 +285,8 @@ def run() -> None:
         metrics.quarantined_tracks = max(0, quarantined_after - quarantined_before)
 
         logger.info("==> music-scan complete")
-        trigger_scan()
+        if imported or asis_imported:
+            trigger_scan()
 
     except Exception:
         metrics.success = False


### PR DESCRIPTION
## Summary
- Triggers a Navidrome library rescan after `music-scan` completes
- Rescan is only triggered when tracks were actually imported (avoids unnecessary API calls on no-op runs)

## Test plan
- [ ] CI passes
- [ ] Verify rescan is triggered after a run that imports tracks
- [ ] Verify rescan is skipped on a run with no new tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)