### PR TITLE
fix: use shutil.move in _quarantine_inbox_leftovers to handle cross-device mounts

### DIFF
--- a/scan/pipeline/scan.py
+++ b/scan/pipeline/scan.py
@@ -101,7 +101,7 @@ def _quarantine_inbox_leftovers() -> int:
         if f.is_file() and f.suffix.lower() in AUDIO_EXTS:
             dest = QUARANTINE / f.relative_to(INBOX)
             dest.parent.mkdir(parents=True, exist_ok=True)
-            f.rename(dest)
+            shutil.move(str(f), dest)
             moved += 1
     return moved
 


### PR DESCRIPTION
Closes #49

## What

Replace `f.rename(dest)` with `shutil.move(str(f), dest)` in `_quarantine_inbox_leftovers()`.

## Why

In the Kubernetes deployment, `inbox` and `quarantine` are separate `subPath` bind mounts of the same NFS PVC. The kernel treats them as distinct mount points, so `os.rename()` (called by `Path.rename()`) returns `EXDEV` (errno 18 — cross-device link). Every `music-scan` run crashes the moment beets skips a track and leaves it in the inbox.

`shutil.move()` handles this correctly: it tries `os.rename()` first and falls back to copy+delete on `EXDEV`. `_move_asis_eligible()` in the same file already uses this pattern correctly.

## Testing

Verified fix by running `music-scan-debug` job against the live cluster. The track that previously caused the crash (`Jim Legxacy - idk idk.m4a`) is correctly quarantined and the job completes successfully.