### PR TITLE
fix: use PUT for Pushgateway to clear stale metrics

### DIFF
--- a/fetch/pipeline/metrics.py
+++ b/fetch/pipeline/metrics.py
@@ -25,7 +25,7 @@ def _push(body: str, job: str) -> None:
         return
     endpoint = f"{url.rstrip('/')}/metrics/job/{job}"
     try:
-        resp = requests.post(endpoint, data=(body + "\n").encode(), timeout=10)
+        resp = requests.put(endpoint, data=(body + "\n").encode(), timeout=10)
         resp.raise_for_status()
     except requests.RequestException as exc:
         logger.warning("Failed to push metrics to %s: %s", endpoint, exc)

--- a/scan/pipeline/metrics.py
+++ b/scan/pipeline/metrics.py
@@ -25,7 +25,7 @@ def _push(body: str, job: str) -> None:
         return
     endpoint = f"{url.rstrip('/')}/metrics/job/{job}"
     try:
-        resp = requests.post(endpoint, data=(body + "\n").encode(), timeout=10)
+        resp = requests.put(endpoint, data=(body + "\n").encode(), timeout=10)
         resp.raise_for_status()
     except requests.RequestException as exc:
         logger.warning("Failed to push metrics to %s: %s", endpoint, exc)


### PR DESCRIPTION
## Problem

`_push()` used `requests.post`, which *merges* into the Pushgateway group — series from previous runs with different label sets persist forever. This meant `last_failure_reason{reason="unexpected_error"}` stayed in the Pushgateway even after the job started succeeding again, showing a misleading stale failure metric.

## Fix

Switch to `requests.put`, which atomically *replaces* the entire metric group for the job. Any series not included in the current push is automatically cleared. Affects both `fetch` and `scan`.

## Test plan

- [ ] Unit tests: unaffected (tests monkeypatch `_push` entirely, so HTTP method is not exercised)
- [ ] After merge: verify `music_scan_last_failure_reason` is absent from Pushgateway after a successful scan run

🤖 Generated with [Claude Code](https://claude.com/claude-code)