### PR TITLE
feat: add SYNC_TIMEOUT_SECONDS soft deadline to ingest loop

### DIFF
--- a/fetch/pipeline/ingest.py
+++ b/fetch/pipeline/ingest.py
@@ -35,9 +35,9 @@ PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
 CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
 
 
-def _deadline_reached(start: float, timeout: int | None) -> bool:
-    """Return True if elapsed seconds since *start* have met or exceeded *timeout*."""
-    return timeout is not None and (time.monotonic() - start) >= timeout
+def _deadline_reached(elapsed: float, timeout: int | None) -> bool:
+    """Return True if *elapsed* seconds have met or exceeded *timeout*."""
+    return timeout is not None and elapsed >= timeout
 
 
 def classify_failure(error_msg: str) -> str:
@@ -292,7 +292,7 @@ def run() -> None:
                 continue
 
             # Soft timeout: stop before the Kubernetes activeDeadlineSeconds fires.
-            if _deadline_reached(start, soft_timeout):
+            if _deadline_reached(time.monotonic() - start, soft_timeout):
                 logger.info(
                     "==> Soft timeout reached (%ds/%ds) — deferring %s to next session",
                     int(time.monotonic() - start),

--- a/fetch/pipeline/ingest.py
+++ b/fetch/pipeline/ingest.py
@@ -35,6 +35,11 @@ PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
 CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
 
 
+def _deadline_reached(start: float, timeout: int | None) -> bool:
+    """Return True if elapsed seconds since *start* have met or exceeded *timeout*."""
+    return timeout is not None and (time.monotonic() - start) >= timeout
+
+
 def classify_failure(error_msg: str) -> str:
     """Map a spotdl error message to a short Prometheus label string."""
     msg = error_msg.lower()
@@ -249,6 +254,20 @@ def run() -> None:
         if session_budget is not None:
             logger.info("Session track budget: %d new tracks across all playlists", session_budget)
 
+        timeout_str = os.environ.get("SYNC_TIMEOUT_SECONDS", "")
+        soft_timeout: int | None = None
+        if timeout_str.strip():
+            try:
+                soft_timeout = int(timeout_str.strip())
+            except ValueError:
+                logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %r — ignoring", timeout_str)
+        if soft_timeout is not None and soft_timeout <= 0:
+            logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %d — ignoring", soft_timeout)
+            soft_timeout = None
+
+        if soft_timeout is not None:
+            logger.info("Soft timeout: %ds — will stop before Kubernetes deadline fires", soft_timeout)
+
         spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
         if not spotdl_files:
             logger.info("No .spotdl files found in %s", SPOTDL_DIR)
@@ -268,6 +287,18 @@ def run() -> None:
             # Budget exhausted: defer remaining playlists to the next session.
             if remaining is not None and remaining <= 0:
                 logger.info("==> Track budget exhausted — deferring %s to next session", name)
+                metrics.playlists_deferred += 1
+                metrics.playlists_total += 1
+                continue
+
+            # Soft timeout: stop before the Kubernetes activeDeadlineSeconds fires.
+            if _deadline_reached(start, soft_timeout):
+                logger.info(
+                    "==> Soft timeout reached (%ds/%ds) — deferring %s to next session",
+                    int(time.monotonic() - start),
+                    soft_timeout,
+                    name,
+                )
                 metrics.playlists_deferred += 1
                 metrics.playlists_total += 1
                 continue

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pipeline.ingest import classify_failure, _collect_removals, _reconcile_playlists, _write_pending_removals
+from pipeline.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, _write_pending_removals
 from pipeline.spotdl_ops import find_track_in_snapshot
 
 
@@ -29,6 +29,27 @@ from pipeline.spotdl_ops import find_track_in_snapshot
 )
 def test_classify_failure(msg: str, expected: str) -> None:
     assert classify_failure(msg) == expected
+
+
+# ---------------------------------------------------------------------------
+# _deadline_reached
+# ---------------------------------------------------------------------------
+
+
+def test_deadline_reached_no_timeout() -> None:
+    assert _deadline_reached(0.0, None) is False
+
+
+def test_deadline_reached_not_yet() -> None:
+    assert _deadline_reached(50.0, 100) is False
+
+
+def test_deadline_reached_exactly_at_limit() -> None:
+    assert _deadline_reached(100.0, 100) is True
+
+
+def test_deadline_reached_past_limit() -> None:
+    assert _deadline_reached(200.0, 100) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`music-ingest` is killed by `activeDeadlineSeconds` when rate limiting is heavy. When Kubernetes fires the deadline, the pod gets SIGTERM/SIGKILL and the Job is marked `DeadlineExceeded` — a failure — regardless of how much work completed. There's no way to recover gracefully from SIGTERM because by the time the signal arrives, it's already too late.

## Solution

Add a `SYNC_TIMEOUT_SECONDS` env var. Before starting each playlist in the sync loop, the script checks elapsed wall-clock time. If the soft timeout is reached, remaining playlists are deferred (same behaviour as `SYNC_TRACK_LIMIT` exhaustion) and the job exits 0 with `success=True` and `playlists_deferred` incremented.

Setting `SYNC_TIMEOUT_SECONDS` well below `activeDeadlineSeconds` (e.g. 6300s vs 7200s) gives ~15 minutes of headroom for metrics push and container shutdown before the hard kill would fire.

## Changes

- `fetch/pipeline/ingest.py`: new `_deadline_reached(start, timeout)` helper; timeout parsed from `SYNC_TIMEOUT_SECONDS`; check added to playlist loop
- `fetch/tests/test_ingest.py`: four tests for `_deadline_reached` (no timeout, not yet, exactly at limit, past limit)

## Test plan

- [ ] Tests pass in Docker dev container: `just test`
- [ ] When `SYNC_TIMEOUT_SECONDS` is reached mid-run, log shows "Soft timeout reached" and remaining playlists show as deferred
- [ ] Job exits 0 (success) — not killed by the hard deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)