### PR TITLE
fix: re-apply source/via tags in item_imported to survive MB autotag

### DIFF
--- a/scan/pipeline/music_pipeline.py
+++ b/scan/pipeline/music_pipeline.py
@@ -16,6 +16,14 @@ Responsibilities
    Handles both singleton (``task.item``) and album (``task.items``) import
    tasks.
 
+   Also caches ``filename → playlist`` in ``_pending_sources`` for step 1a.
+
+1a. **tag_source_on_stored** (``item_imported``): re-applies ``source=`` and
+    ``via=`` after the item is fully persisted, then calls ``item.store()``.
+    MusicBrainz autotag can replace the item's metadata dict wholesale between
+    steps 1 and 1a, silently discarding the flex attributes.  This hook
+    guarantees the tags survive to the database on clean first-time imports.
+
 2. **Duplicate protection** (``import_task_choice``): when duplicates exist in
    the library for the incoming track:
 
@@ -89,7 +97,11 @@ def _items_from_task(task) -> list:
 class MusicPipelinePlugin(BeetsPlugin):
     def __init__(self):
         super().__init__("music_pipeline")
+        # filename → playlist name; populated at import_task_created, consumed
+        # at item_imported to survive MusicBrainz autotag metadata replacement.
+        self._pending_sources: dict[str, str] = {}
         self.register_listener("import_task_created", self.tag_source_on_created)
+        self.register_listener("item_imported", self.tag_source_on_stored)
         self.register_listener("import_task_choice", self.handle_duplicates)
 
     def tag_source_on_created(self, session, task):
@@ -98,6 +110,9 @@ class MusicPipelinePlugin(BeetsPlugin):
         Fires from handle_created() during read_tasks — always, regardless of
         autotag mode — while item.path still points to the inbox file (before
         any pipeline stage runs).
+
+        Also caches filename→playlist in _pending_sources so tag_source_on_stored
+        can re-apply the tags after MusicBrainz autotag may have discarded them.
         """
         for item in _items_from_task(task):
             playlist = _playlist_from_path(item.path)
@@ -105,9 +120,31 @@ class MusicPipelinePlugin(BeetsPlugin):
                 continue
             item["source"] = playlist
             item["via"] = "spotdl"
+            path = item.path.decode() if isinstance(item.path, bytes) else item.path
+            self._pending_sources[Path(path).name] = playlist
             self._log.debug(
                 "tagged incoming track source={} via=spotdl: {}", playlist, item.path
             )
+
+    def tag_source_on_stored(self, lib, item):
+        """Re-apply source= and via= after the item is persisted to the library.
+
+        Fires from item_imported, after autotag and item.store() have run.
+        MusicBrainz autotag can replace the item's metadata dict wholesale,
+        discarding flex attributes set earlier by tag_source_on_created.
+        Consuming from _pending_sources here guarantees the tags are written to
+        the database even on a clean first-time import with no duplicates.
+        """
+        path = item.path.decode() if isinstance(item.path, bytes) else item.path
+        playlist = self._pending_sources.pop(Path(path).name, None)
+        if playlist is None:
+            return
+        item["source"] = playlist
+        item["via"] = "spotdl"
+        item.store()
+        self._log.debug(
+            "persisted source={} via=spotdl on stored item: {}", playlist, item.path
+        )
 
     def handle_duplicates(self, session, task):
         """Protect manually-imported tracks from spotdl overwrites.

--- a/scan/tests/test_music_pipeline.py
+++ b/scan/tests/test_music_pipeline.py
@@ -23,6 +23,7 @@ def _make_plugin() -> MusicPipelinePlugin:
     """
     plugin = MusicPipelinePlugin.__new__(MusicPipelinePlugin)
     plugin._log = MagicMock()
+    plugin._pending_sources = {}
     return plugin
 
 
@@ -139,6 +140,93 @@ def test_tag_source_on_created_album_task_tags_all_items() -> None:
     for item in (item1, item2):
         item.__setitem__.assert_any_call("source", "pop")
         item.__setitem__.assert_any_call("via", "spotdl")
+
+
+# ---------------------------------------------------------------------------
+# MusicPipelinePlugin.tag_source_on_created — pending-source cache
+# ---------------------------------------------------------------------------
+
+def test_tag_source_on_created_caches_pending_source() -> None:
+    """Filename→playlist mapping must be cached for later item_imported re-apply."""
+    plugin = _make_plugin()
+    item = _item("/root/Music/inbox/spotdl/jazz/track.m4a")
+    task = _task(item=item)
+
+    plugin.tag_source_on_created(session=MagicMock(), task=task)
+
+    assert plugin._pending_sources["track.m4a"] == "jazz"
+
+
+def test_tag_source_on_created_outside_inbox_not_cached() -> None:
+    plugin = _make_plugin()
+    item = _item("/root/Music/library/Artist/Album/track.m4a")
+    task = _task(item=item)
+
+    plugin.tag_source_on_created(session=MagicMock(), task=task)
+
+    assert plugin._pending_sources == {}
+
+
+def test_tag_source_on_created_album_task_caches_all_items() -> None:
+    plugin = _make_plugin()
+    item1 = _item("/root/Music/inbox/spotdl/pop/a.m4a")
+    item2 = _item("/root/Music/inbox/spotdl/pop/b.m4a")
+    task = _task(items=[item1, item2])
+
+    plugin.tag_source_on_created(session=MagicMock(), task=task)
+
+    assert plugin._pending_sources["a.m4a"] == "pop"
+    assert plugin._pending_sources["b.m4a"] == "pop"
+
+
+# ---------------------------------------------------------------------------
+# MusicPipelinePlugin.tag_source_on_stored — item_imported re-apply
+# ---------------------------------------------------------------------------
+
+def test_tag_source_on_stored_applies_and_stores_source() -> None:
+    """After autotag mutates the item, item_imported must re-apply source/via."""
+    plugin = _make_plugin()
+    plugin._pending_sources = {"track.m4a": "jazz"}
+    item = _item("/root/Music/library/Artist/Album/track.m4a")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    item.__setitem__.assert_any_call("source", "jazz")
+    item.__setitem__.assert_any_call("via", "spotdl")
+    item.store.assert_called_once()
+
+
+def test_tag_source_on_stored_consumes_pending_entry() -> None:
+    """The cache entry must be removed after use to prevent memory leaks."""
+    plugin = _make_plugin()
+    plugin._pending_sources = {"track.m4a": "jazz"}
+    item = _item("/root/Music/library/Artist/Album/track.m4a")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    assert "track.m4a" not in plugin._pending_sources
+
+
+def test_tag_source_on_stored_unknown_item_does_nothing() -> None:
+    """Items not originating from the spotdl inbox must be left untouched."""
+    plugin = _make_plugin()
+    item = _item("/root/Music/library/Artist/Album/track.m4a")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    item.__setitem__.assert_not_called()
+    item.store.assert_not_called()
+
+
+def test_tag_source_on_stored_bytes_path() -> None:
+    plugin = _make_plugin()
+    plugin._pending_sources = {"track.m4a": "rock"}
+    item = _item(b"/root/Music/library/Artist/Album/track.m4a")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    item.__setitem__.assert_any_call("source", "rock")
+    item.store.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `_pending_sources: dict[str, str]` (filename → playlist) to `MusicPipelinePlugin.__init__`
- `tag_source_on_created` now populates the cache in addition to setting item attrs
- New `tag_source_on_stored` listener on `item_imported` pops the cache entry, re-applies `source=` / `via=spotdl`, and calls `item.store()` to guarantee the tags are written to the database

## Root cause

`import_task_created` fires while the item still points to the inbox file (before autotag). MusicBrainz lookup then replaces the item's metadata dict wholesale, discarding any flex attributes set during `import_task_created`. `handle_duplicates` already contained a workaround re-apply, but only fires when duplicates are found — clean first-time imports went through with `source` unset in the database, producing empty `.m3u` playlists.

## Test plan

- [ ] All existing `test_music_pipeline.py` tests still pass (no regressions)
- [ ] `test_tag_source_on_created_caches_pending_source` — cache populated on inbox track
- [ ] `test_tag_source_on_created_outside_inbox_not_cached` — non-inbox tracks not cached
- [ ] `test_tag_source_on_created_album_task_caches_all_items` — all album items cached
- [ ] `test_tag_source_on_stored_applies_and_stores_source` — source/via set and store() called
- [ ] `test_tag_source_on_stored_consumes_pending_entry` — cache entry removed after apply
- [ ] `test_tag_source_on_stored_unknown_item_does_nothing` — non-inbox items untouched
- [ ] `test_tag_source_on_stored_bytes_path` — bytes path handled correctly

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)