### PR TITLE
fix: key _pending_sources by title to survive beets file rename

### DIFF
--- a/scan/pipeline/music_pipeline.py
+++ b/scan/pipeline/music_pipeline.py
@@ -16,13 +16,18 @@ Responsibilities
    Handles both singleton (``task.item``) and album (``task.items``) import
    tasks.
 
-   Also caches ``filename → playlist`` in ``_pending_sources`` for step 1a.
+   Caches both ``filename → playlist`` and ``title → playlist`` in
+   ``_pending_sources`` for step 1a.
 
 1a. **tag_source_on_stored** (``item_imported``): re-applies ``source=`` and
     ``via=`` after the item is fully persisted, then calls ``item.store()``.
-    MusicBrainz autotag can replace the item's metadata dict wholesale between
-    steps 1 and 1a, silently discarding the flex attributes.  This hook
-    guarantees the tags survive to the database on clean first-time imports.
+    Two things can discard the flex attributes between steps 1 and 1a:
+    (a) MusicBrainz autotag replaces the item metadata dict wholesale, and
+    (b) beets renames the file on import (spotdl names ``Artist - Title.m4a``;
+    beets renames to ``NN - Title.m4a``), so the inbox filename no longer
+    matches ``item.path`` at ``item_imported`` time.  The title-based key
+    survives both.  This hook guarantees the tags land in the database on
+    clean first-time imports.
 
 2. **Duplicate protection** (``import_task_choice``): when duplicates exist in
    the library for the incoming track:
@@ -97,8 +102,12 @@ def _items_from_task(task) -> list:
 class MusicPipelinePlugin(BeetsPlugin):
     def __init__(self):
         super().__init__("music_pipeline")
-        # filename → playlist name; populated at import_task_created, consumed
-        # at item_imported to survive MusicBrainz autotag metadata replacement.
+        # Keys: inbox filename OR normalised title → playlist name.
+        # Populated at import_task_created, consumed at item_imported.
+        # Two keys per track because beets renames the file on import
+        # (spotdl names "Artist - Title.m4a"; beets renames to "NN - Title.m4a"),
+        # so the filename key no longer matches at item_imported time.
+        # The title key survives both the rename and MB autotag metadata replacement.
         self._pending_sources: dict[str, str] = {}
         self.register_listener("import_task_created", self.tag_source_on_created)
         self.register_listener("item_imported", self.tag_source_on_stored)
@@ -111,8 +120,10 @@ class MusicPipelinePlugin(BeetsPlugin):
         autotag mode — while item.path still points to the inbox file (before
         any pipeline stage runs).
 
-        Also caches filename→playlist in _pending_sources so tag_source_on_stored
-        can re-apply the tags after MusicBrainz autotag may have discarded them.
+        Caches both the inbox filename and the normalised title in
+        _pending_sources so tag_source_on_stored can re-apply the tags after
+        MusicBrainz autotag may have discarded them and beets has renamed the
+        file.
         """
         for item in _items_from_task(task):
             playlist = _playlist_from_path(item.path)
@@ -122,6 +133,9 @@ class MusicPipelinePlugin(BeetsPlugin):
             item["via"] = "spotdl"
             path = item.path.decode() if isinstance(item.path, bytes) else item.path
             self._pending_sources[Path(path).name] = playlist
+            title = (item.title or "").lower()
+            if title:
+                self._pending_sources[title] = playlist
             self._log.debug(
                 "tagged incoming track source={} via=spotdl: {}", playlist, item.path
             )
@@ -130,13 +144,25 @@ class MusicPipelinePlugin(BeetsPlugin):
         """Re-apply source= and via= after the item is persisted to the library.
 
         Fires from item_imported, after autotag and item.store() have run.
-        MusicBrainz autotag can replace the item's metadata dict wholesale,
-        discarding flex attributes set earlier by tag_source_on_created.
-        Consuming from _pending_sources here guarantees the tags are written to
-        the database even on a clean first-time import with no duplicates.
+        MusicBrainz autotag can replace the item's metadata dict wholesale and
+        beets renames the file, both of which discard the flex attributes set
+        earlier by tag_source_on_created.  We try the post-rename filename
+        first (handles no-rename edge cases), then fall back to the normalised
+        title (the common case after a move-import).
         """
         path = item.path.decode() if isinstance(item.path, bytes) else item.path
+        title = (item.title or "").lower()
         playlist = self._pending_sources.pop(Path(path).name, None)
+        if playlist is not None:
+            # Matched on filename — also clean the title key to avoid stale entries.
+            if title:
+                self._pending_sources.pop(title, None)
+        elif title:
+            playlist = self._pending_sources.pop(title, None)
+            # The original spotdl inbox filename key cannot be recovered from
+            # item.path (which is now the renamed library path), so it may
+            # remain in _pending_sources.  That is harmless: _pending_sources
+            # is session-scoped and is GC'd when the import session ends.
         if playlist is None:
             return
         item["source"] = playlist

--- a/scan/tests/test_music_pipeline.py
+++ b/scan/tests/test_music_pipeline.py
@@ -27,10 +27,11 @@ def _make_plugin() -> MusicPipelinePlugin:
     return plugin
 
 
-def _item(path: str, source: str = "", via: str = "") -> MagicMock:
+def _item(path: str, source: str = "", via: str = "", title: str = "") -> MagicMock:
     """Mock beets Item with a path and readable/writable flexible attributes."""
     m = MagicMock()
     m.path = path
+    m.title = title
     data = {"source": source, "via": via}
     m.get = lambda k, default="": data.get(k, default)
     # __setitem__ tracked by MagicMock; also update data so .get() sees writes.
@@ -146,15 +147,27 @@ def test_tag_source_on_created_album_task_tags_all_items() -> None:
 # MusicPipelinePlugin.tag_source_on_created — pending-source cache
 # ---------------------------------------------------------------------------
 
-def test_tag_source_on_created_caches_pending_source() -> None:
-    """Filename→playlist mapping must be cached for later item_imported re-apply."""
+def test_tag_source_on_created_caches_filename_and_title() -> None:
+    """Both the inbox filename and the normalised title must be cached."""
     plugin = _make_plugin()
-    item = _item("/root/Music/inbox/spotdl/jazz/track.m4a")
+    item = _item("/root/Music/inbox/spotdl/jazz/Artist - My Track.m4a", title="My Track")
     task = _task(item=item)
 
     plugin.tag_source_on_created(session=MagicMock(), task=task)
 
-    assert plugin._pending_sources["track.m4a"] == "jazz"
+    assert plugin._pending_sources["Artist - My Track.m4a"] == "jazz"
+    assert plugin._pending_sources["my track"] == "jazz"
+
+
+def test_tag_source_on_created_no_title_caches_filename_only() -> None:
+    """When title is empty only the filename key is stored."""
+    plugin = _make_plugin()
+    item = _item("/root/Music/inbox/spotdl/jazz/track.m4a", title="")
+    task = _task(item=item)
+
+    plugin.tag_source_on_created(session=MagicMock(), task=task)
+
+    assert plugin._pending_sources == {"track.m4a": "jazz"}
 
 
 def test_tag_source_on_created_outside_inbox_not_cached() -> None:
@@ -169,25 +182,27 @@ def test_tag_source_on_created_outside_inbox_not_cached() -> None:
 
 def test_tag_source_on_created_album_task_caches_all_items() -> None:
     plugin = _make_plugin()
-    item1 = _item("/root/Music/inbox/spotdl/pop/a.m4a")
-    item2 = _item("/root/Music/inbox/spotdl/pop/b.m4a")
+    item1 = _item("/root/Music/inbox/spotdl/pop/a.m4a", title="Alpha")
+    item2 = _item("/root/Music/inbox/spotdl/pop/b.m4a", title="Beta")
     task = _task(items=[item1, item2])
 
     plugin.tag_source_on_created(session=MagicMock(), task=task)
 
     assert plugin._pending_sources["a.m4a"] == "pop"
+    assert plugin._pending_sources["alpha"] == "pop"
     assert plugin._pending_sources["b.m4a"] == "pop"
+    assert plugin._pending_sources["beta"] == "pop"
 
 
 # ---------------------------------------------------------------------------
 # MusicPipelinePlugin.tag_source_on_stored — item_imported re-apply
 # ---------------------------------------------------------------------------
 
-def test_tag_source_on_stored_applies_and_stores_source() -> None:
-    """After autotag mutates the item, item_imported must re-apply source/via."""
+def test_tag_source_on_stored_applies_via_filename_key() -> None:
+    """Filename key lookup works for items that beets didn't rename."""
     plugin = _make_plugin()
     plugin._pending_sources = {"track.m4a": "jazz"}
-    item = _item("/root/Music/library/Artist/Album/track.m4a")
+    item = _item("/root/Music/library/Artist/Album/track.m4a", title="Track")
 
     plugin.tag_source_on_stored(lib=MagicMock(), item=item)
 
@@ -196,21 +211,62 @@ def test_tag_source_on_stored_applies_and_stores_source() -> None:
     item.store.assert_called_once()
 
 
-def test_tag_source_on_stored_consumes_pending_entry() -> None:
-    """The cache entry must be removed after use to prevent memory leaks."""
+def test_tag_source_on_stored_applies_via_title_key_after_rename() -> None:
+    """Title key lookup resolves when beets renamed the file (the common case).
+
+    spotdl names files "Artist - Title.m4a"; beets renames to "NN - Title.m4a".
+    The filename key no longer matches, so the title key must be used.
+    """
     plugin = _make_plugin()
-    plugin._pending_sources = {"track.m4a": "jazz"}
-    item = _item("/root/Music/library/Artist/Album/track.m4a")
+    plugin._pending_sources = {
+        "Artist Name - My Track.m4a": "jazz",  # spotdl original filename
+        "my track": "jazz",                     # title key added by tag_source_on_created
+    }
+    # item_imported fires with the beets-renamed library path
+    item = _item("/root/Music/library/Artist Name/Album/03 - My Track.m4a", title="My Track")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    item.__setitem__.assert_any_call("source", "jazz")
+    item.__setitem__.assert_any_call("via", "spotdl")
+    item.store.assert_called_once()
+
+
+def test_tag_source_on_stored_filename_match_also_cleans_title_key() -> None:
+    """When the filename key matches, the title key is also cleaned up."""
+    plugin = _make_plugin()
+    plugin._pending_sources = {"track.m4a": "jazz", "my track": "jazz"}
+    item = _item("/root/Music/library/Artist/Album/track.m4a", title="My Track")
 
     plugin.tag_source_on_stored(lib=MagicMock(), item=item)
 
     assert "track.m4a" not in plugin._pending_sources
+    assert "my track" not in plugin._pending_sources
+
+
+def test_tag_source_on_stored_title_match_leaves_stale_filename_key() -> None:
+    """When the title key is the fallback match, the original spotdl filename key
+    cannot be recovered from the renamed item.path and is left in the cache.
+    It is harmless — _pending_sources is session-scoped and GC'd after the import.
+    """
+    plugin = _make_plugin()
+    plugin._pending_sources = {
+        "Artist Name - My Track.m4a": "jazz",
+        "my track": "jazz",
+    }
+    item = _item("/root/Music/library/Artist Name/Album/03 - My Track.m4a", title="My Track")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    assert "my track" not in plugin._pending_sources
+    # Original spotdl filename key cannot be cleaned — it remains (session-scoped).
+    assert "Artist Name - My Track.m4a" in plugin._pending_sources
 
 
 def test_tag_source_on_stored_unknown_item_does_nothing() -> None:
     """Items not originating from the spotdl inbox must be left untouched."""
     plugin = _make_plugin()
-    item = _item("/root/Music/library/Artist/Album/track.m4a")
+    item = _item("/root/Music/library/Artist/Album/track.m4a", title="Track")
 
     plugin.tag_source_on_stored(lib=MagicMock(), item=item)
 
@@ -221,7 +277,7 @@ def test_tag_source_on_stored_unknown_item_does_nothing() -> None:
 def test_tag_source_on_stored_bytes_path() -> None:
     plugin = _make_plugin()
     plugin._pending_sources = {"track.m4a": "rock"}
-    item = _item(b"/root/Music/library/Artist/Album/track.m4a")
+    item = _item(b"/root/Music/library/Artist/Album/track.m4a", title="Track")
 
     plugin.tag_source_on_stored(lib=MagicMock(), item=item)
 


### PR DESCRIPTION
## Summary

- `tag_source_on_stored` was looking up `_pending_sources` by `Path(item.path).name`, which at `item_imported` time is the **beets-renamed** library filename (e.g. `04 - Bushel Hyde.m4a`). The dict was populated in `tag_source_on_created` with the original **spotdl inbox** filename (e.g. `Jessica Pratt - Bushel Hyde.m4a`). These never match, so `source=` was silently never persisted for any track beets renamed on import — i.e. every track in a normal autotag run.
- Fix: also cache by normalised `item.title` at task-creation time and fall back to the title key in `tag_source_on_stored` when the filename key misses. Title is stable across both the MB metadata replacement and the file rename.
- Adds two new test cases covering the rename (common) and no-rename (edge) paths, and documents the stale-key behaviour for the title-match path.

## Root cause trace

1. `import_task_created`: sets `item["source"]`, caches `{"Jessica Pratt - Bushel Hyde.m4a": "aaaaaaah"}`
2. MB autotag: replaces item metadata dict (issue #56) — `source` lost
3. `import_task_choice` → `handle_duplicates`: re-applies `source` from inbox path ✓
4. `apply_choices()`: applies final MB metadata, wipes flex attrs again
5. `item.move()` → `item.store()`: saved to DB without `source`
6. `item_imported` → `tag_source_on_stored`: looks up `"04 - Bushel Hyde.m4a"` → **not found** → no-op

With this fix, step 6 falls back to the title key `"bushel hyde"` → found → `source` persisted.

## Test plan

- [x] `pytest scan/tests/test_music_pipeline.py` — 26 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)