### PR TITLE
refactor: remove redundant source/via re-apply from handle_duplicates

### DIFF
--- a/scan/pipeline/music_pipeline.py
+++ b/scan/pipeline/music_pipeline.py
@@ -22,7 +22,9 @@ Responsibilities
 1a. **tag_source_on_stored** (``item_imported``): re-applies ``source=`` and
     ``via=`` after the item is fully persisted, then calls ``item.store()``.
     Two things can discard the flex attributes between steps 1 and 1a:
-    (a) MusicBrainz autotag replaces the item metadata dict wholesale, and
+    (a) beets' dirty-field tracking is reset during candidate lookup, so
+    flex attributes set in memory at ``import_task_created`` are not marked
+    dirty for the eventual ``item.add(lib)`` call; and
     (b) beets renames the file on import (spotdl names ``Artist - Title.m4a``;
     beets renames to ``NN - Title.m4a``), so the inbox filename no longer
     matches ``item.path`` at ``item_imported`` time.  The title-based key
@@ -184,14 +186,6 @@ class MusicPipelinePlugin(BeetsPlugin):
         # Mirrors the guard in beets' own _resolve_duplicates().
         if not items or task.choice_flag not in _WILL_APPLY:
             return
-
-        # Re-apply source= in case MB lookup mutated item metadata.
-        for item in items:
-            playlist = _playlist_from_path(item.path)
-            if playlist is None:
-                continue
-            item["source"] = playlist
-            item["via"] = "spotdl"
 
         try:
             found = task.find_duplicates(session.lib)


### PR DESCRIPTION
## Summary

- Removes the defensive `source`/`via` re-apply block inside `handle_duplicates` (fired at `import_task_choice`)
- Corrects the module docstring which incorrectly described beets autotag as replacing the item metadata dict "wholesale"

## Why it's safe

`tag_source_on_stored` (via `item_imported`) already guarantees `source`/`via` are persisted for any item that reaches the APPLY/ASIS/RETAG path. The removed block fired *before* `item_imported`, so it was redundant. In the SKIP path `item_imported` never fires, but there's nothing to persist anyway. `find_duplicates()` uses standard fields (title, artist, mb_trackid), not flex attributes, so the re-apply had no effect on duplicate detection.

The corrected docstring explains the actual mechanism: flex attribute loss between `import_task_created` and `item.add(lib)` is caused by beets resetting dirty-field tracking during candidate lookup, not by autotag replacing the item dict.

## Test plan

- [ ] CI passes (unit tests for `handle_duplicates` exercise the duplicate-protection logic)
- [ ] Manual scan confirms `source=` tags are still present after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)