### PR TITLE
refactor: rename pipeline packages to music_fetch / music_scan

### DIFF
--- a/config/beets/config.yaml
+++ b/config/beets/config.yaml
@@ -30,7 +30,7 @@ paths:
   comp: Various Artists/$album/$track - $title
 
 pluginpath:
-  - /app/pipeline
+  - /app/music_scan
 
 plugins: musicbrainz chroma fromfilename fetchart embedart scrub duplicates music_pipeline
 

--- a/fetch/Dockerfile
+++ b/fetch/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
 
 # Install the pipeline package — entry points land in /usr/local/bin/
-COPY pipeline/ /app/pipeline/
+COPY music_fetch/ /app/music_fetch/
 COPY pyproject.toml /app/pyproject.toml
 RUN pip install --no-cache-dir -e /app
 

--- a/fetch/music_fetch/cli.py
+++ b/fetch/music_fetch/cli.py
@@ -1,0 +1,22 @@
+"""Console entry points for the fetch container."""
+
+from __future__ import annotations
+
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S%z",
+)
+
+
+def main() -> None:
+    """Entry point: music-ingest."""
+    try:
+        from music_fetch.ingest import run  # noqa: PLC0415
+    except ImportError as exc:
+        import sys
+        print(f"[music-ingest] Failed to import pipeline: {exc}. Check container installation.", file=sys.stderr)
+        sys.exit(1)
+    run()

--- a/fetch/music_fetch/config.py
+++ b/fetch/music_fetch/config.py
@@ -1,0 +1,40 @@
+"""Playlist configuration: parsing playlists.conf and the PlaylistConfig dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_CONF = Path("/root/.config/music-pipeline/playlists.conf")
+
+
+@dataclass
+class PlaylistConfig:
+    name: str
+    url: str
+    nosync: bool = False
+
+
+def load_playlists(path: Path = DEFAULT_CONF) -> list[PlaylistConfig]:
+    """Parse playlists.conf and return a list of PlaylistConfig entries.
+
+    Format: one entry per line — ``name  spotify-url  [nosync]``
+    Lines starting with # and blank lines are ignored.
+    """
+    playlists: list[PlaylistConfig] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#")[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            # malformed — caller can warn if desired
+            continue
+        playlists.append(
+            PlaylistConfig(
+                name=parts[0],
+                url=parts[1],
+                nosync=len(parts) >= 3 and parts[2] == "nosync",
+            )
+        )
+    return playlists

--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -1,0 +1,363 @@
+"""music-ingest: reconcile playlists.conf → daily spotdl sync loop → write pending-removals.
+
+On each run:
+1. Reconcile disk state with playlists.conf:
+   a. Provision new playlists (spotdl save for entries without a .spotdl file).
+   b. Reconcile .nosync sentinels.
+   c. Queue whole-playlist removals for playlists removed from config.
+   d. Delete .spotdl file and download dir for removed playlists.
+2. For each remaining .spotdl playlist:
+   a. Diff old vs new Spotify URL sets to find removed tracks.
+   b. Download new tracks (overwrite=skip ignores already-downloaded files).
+   c. Write removed track info to .pending-removals.json on the shared volume.
+   music-scan reads this file to clear beets source tags (soft delete — files stay in library).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+
+from music_fetch.config import load_playlists
+from music_fetch.metrics import IngestMetrics
+from music_fetch.spotdl_ops import find_track_in_snapshot, save_playlist, sync_playlist
+
+logger = logging.getLogger(__name__)
+
+SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
+COOKIE_FILE = Path("/root/.config/spotdl/cookies.txt")
+PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
+CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
+
+
+def _deadline_reached(elapsed: float, timeout: int | None) -> bool:
+    """Return True if *elapsed* seconds have met or exceeded *timeout*."""
+    return timeout is not None and elapsed >= timeout
+
+
+def classify_failure(error_msg: str) -> str:
+    """Map a spotdl error message to a short Prometheus label string."""
+    msg = error_msg.lower()
+    if re.search(r"spotifyerror|invalid credentials", msg):
+        return "auth_spotify"
+    if re.search(r"http error 403|sign in to confirm|cookies", msg):
+        return "auth_youtube"
+    if re.search(r"429|too many requests", msg):
+        return "rate_limited"
+    return "spotdl_error"
+
+
+def _preflight() -> str | None:
+    """Return a failure-reason string if pre-flight checks fail, else None."""
+    if not COOKIE_FILE.exists():
+        logger.error("Error: YouTube Premium cookies not found at %s", COOKIE_FILE)
+        logger.error("See README for export instructions.")
+        return "missing_cookies"
+
+    if not os.environ.get("SPOTIFY_CLIENT_ID") or not os.environ.get("SPOTIFY_CLIENT_SECRET"):
+        logger.error("Error: SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set")
+        return "auth_spotify"
+
+    usage = shutil.disk_usage(Path.home() / "Music")
+    free_gb = usage.free / 1024**3
+    if free_gb < 1.0:
+        logger.error("Error: less than 1 GB free on ~/Music (%.2f GB available)", free_gb)
+        return "disk_full"
+
+    return None
+
+
+def _jitter() -> None:
+    """Sleep a random interval if SYNC_JITTER_SECONDS is set."""
+    import random
+
+    jitter = int(os.environ.get("SYNC_JITTER_SECONDS") or "0")
+    if jitter > 0:
+        delay = random.randint(0, jitter)
+        logger.debug("Jitter: sleeping %d seconds", delay)
+        time.sleep(delay)
+
+
+def _reconcile_playlists() -> list[str]:
+    """Reconcile disk state with playlists.conf; return list of removed source names.
+
+    - Provisions new playlist entries (spotdl save for entries without .spotdl).
+    - Reconciles .nosync sentinels to match config.
+    - Detects playlists present on disk but absent from config.
+    - Deletes .spotdl file and download dir for removed playlists.
+
+    Returns a list of source names that were removed and should have their beets
+    tags cleared by the scan container.  Returns an empty list if playlists.conf
+    does not exist (backwards-compatible: no reconciliation occurs).
+    """
+    if not CONF_PATH.exists():
+        logger.warning("playlists.conf not found at %s — skipping declarative reconciliation", CONF_PATH)
+        return []
+
+    playlists = load_playlists(CONF_PATH)
+    conf_names = {pl.name for pl in playlists}
+
+    # Provision new entries and reconcile .nosync sentinels.
+    for pl in playlists:
+        spotdl_file = SPOTDL_DIR / f"{pl.name}.spotdl"
+        output_dir = SPOTDL_DIR / pl.name
+        nosync_file = SPOTDL_DIR / f"{pl.name}.nosync"
+
+        if not spotdl_file.exists():
+            logger.info("==> Provisioning new playlist: %s", pl.name)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            save_playlist(url=pl.url, spotdl_file=spotdl_file)
+
+        if pl.nosync:
+            if not nosync_file.exists():
+                logger.info("    Creating .nosync sentinel for %s", pl.name)
+                nosync_file.touch()
+        else:
+            if nosync_file.exists():
+                logger.info("    Removing .nosync sentinel for %s (nosync flag removed from config)", pl.name)
+                nosync_file.unlink()
+
+    # Detect playlists on disk that are no longer in config.
+    existing_names = {f.stem for f in SPOTDL_DIR.glob("*.spotdl")}
+    removed_names = existing_names - conf_names
+
+    remove_sources: list[str] = []
+    for name in sorted(removed_names):
+        logger.info("==> Playlist removed from config: %s — queuing cleanup", name)
+        remove_sources.append(name)
+        (SPOTDL_DIR / f"{name}.spotdl").unlink(missing_ok=True)
+        (SPOTDL_DIR / f"{name}.nosync").unlink(missing_ok=True)
+        download_dir = SPOTDL_DIR / name
+        if download_dir.exists():
+            shutil.rmtree(download_dir)
+
+    return remove_sources
+
+
+def _collect_removals(
+    pending: list[dict],
+    removed_urls: set[str],
+    old_songs: list[dict],
+    playlist_name: str,
+) -> None:
+    """Collect removed track info for deferred beets tag cleanup by music-scan."""
+    if not removed_urls:
+        return
+
+    logger.info(
+        "==> Scheduling unlinking of %d removed track(s) from playlist: %s",
+        len(removed_urls),
+        playlist_name,
+    )
+    for url in removed_urls:
+        entry = find_track_in_snapshot(old_songs, url)
+        if entry is None:
+            logger.warning("  Could not find snapshot entry for removed URL: %s", url)
+            continue
+
+        title = entry.get("name", "")
+        artists = entry.get("artists", [])
+        artist = artists[0] if artists else ""
+        logger.info("  Scheduling unlink: %s — %s", title, artist)
+        pending.append({"title": title, "artist": artist, "source": playlist_name})
+
+
+def _write_pending_removals(pending: list[dict], remove_sources: list[str] | None = None) -> None:
+    """Write pending source-tag removals to the shared volume for music-scan.
+
+    Writes {"tracks": [...], "remove_sources": [...]} format.
+    Merges with any existing file so multiple fetch runs before a scan don't
+    overwrite each other.  Supports merging with old list-format files.
+    """
+    remove_sources = remove_sources or []
+    if not pending and not remove_sources:
+        return
+
+    PENDING_REMOVALS.parent.mkdir(parents=True, exist_ok=True)
+
+    # Load and merge — safe if fetch runs multiple times before scan processes the file.
+    existing_tracks: list[dict] = []
+    existing_remove_sources: list[str] = []
+    if PENDING_REMOVALS.exists():
+        try:
+            with open(PENDING_REMOVALS, encoding="utf-8") as fh:
+                existing = json.load(fh)
+            if isinstance(existing, list):
+                # Old format: just a list of track entries.
+                existing_tracks = existing
+            else:
+                existing_tracks = existing.get("tracks", [])
+                existing_remove_sources = existing.get("remove_sources", [])
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error("Could not read %s — discarding prior pending removals: %s", PENDING_REMOVALS, exc)
+
+    merged_tracks = existing_tracks + pending
+    merged_remove_sources = existing_remove_sources + remove_sources
+
+    # Atomic write: write to a temp file then rename so a mid-write failure never
+    # truncates the existing file.
+    tmp = PENDING_REMOVALS.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(
+            {"tracks": merged_tracks, "remove_sources": merged_remove_sources},
+            fh,
+            indent=2,
+            ensure_ascii=False,
+        )
+    tmp.replace(PENDING_REMOVALS)
+
+    logger.info(
+        "==> Wrote %d pending track removal(s) and %d source removal(s) to %s",
+        len(pending),
+        len(remove_sources),
+        PENDING_REMOVALS,
+    )
+
+
+def run() -> None:
+    """Execute the full ingest pipeline, push metrics on completion."""
+    metrics = IngestMetrics()
+    start = time.monotonic()
+
+    failure_reason = _preflight()
+    if failure_reason:
+        metrics.success = False
+        metrics.failure_reason = failure_reason
+        metrics.duration_seconds = int(time.monotonic() - start)
+        metrics.push()
+        raise SystemExit(1)
+
+    _jitter()
+
+    try:
+        logger.info("==> music-ingest starting")
+
+        remove_sources = _reconcile_playlists()
+
+        track_limit_str = os.environ.get("SYNC_TRACK_LIMIT", "")
+        session_budget: int | None = None
+        if track_limit_str.strip():
+            try:
+                session_budget = int(track_limit_str.strip())
+            except ValueError:
+                logger.error("SYNC_TRACK_LIMIT must be a positive integer, got %r — ignoring", track_limit_str)
+        if session_budget is not None and session_budget <= 0:
+            logger.error("SYNC_TRACK_LIMIT must be a positive integer, got %d — ignoring", session_budget)
+            session_budget = None
+        remaining: int | None = session_budget
+
+        if session_budget is not None:
+            logger.info("Session track budget: %d new tracks across all playlists", session_budget)
+
+        timeout_str = os.environ.get("SYNC_TIMEOUT_SECONDS", "")
+        soft_timeout: int | None = None
+        if timeout_str.strip():
+            try:
+                soft_timeout = int(timeout_str.strip())
+            except ValueError:
+                logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %r — ignoring", timeout_str)
+        if soft_timeout is not None and soft_timeout <= 0:
+            logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %d — ignoring", soft_timeout)
+            soft_timeout = None
+
+        if soft_timeout is not None:
+            logger.info("Soft timeout: %ds — will stop before Kubernetes deadline fires", soft_timeout)
+
+        spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
+        if not spotdl_files:
+            logger.info("No .spotdl files found in %s", SPOTDL_DIR)
+
+        pending_removals: list[dict] = []
+
+        for spotdl_file in spotdl_files:
+            name = spotdl_file.stem
+
+            # .nosync: skip spotdl sync for frozen playlists
+            if (SPOTDL_DIR / f"{name}.nosync").exists():
+                logger.info("==> Skipping sync for static playlist: %s (.nosync present)", name)
+                metrics.playlists_skipped += 1
+                metrics.playlists_total += 1
+                continue
+
+            # Budget exhausted: defer remaining playlists to the next session.
+            if remaining is not None and remaining <= 0:
+                logger.info("==> Track budget exhausted — deferring %s to next session", name)
+                metrics.playlists_deferred += 1
+                metrics.playlists_total += 1
+                continue
+
+            # Soft timeout: stop before the Kubernetes activeDeadlineSeconds fires.
+            if _deadline_reached(time.monotonic() - start, soft_timeout):
+                logger.info(
+                    "==> Soft timeout reached (%ds/%ds) — deferring %s to next session",
+                    int(time.monotonic() - start),
+                    soft_timeout,
+                    name,
+                )
+                metrics.playlists_deferred += 1
+                metrics.playlists_total += 1
+                continue
+
+            # Validate JSON before we attempt a sync
+            try:
+                with open(spotdl_file, encoding="utf-8") as fh:
+                    sync_data = json.load(fh)
+            except json.JSONDecodeError:
+                logger.warning("WARNING: %s is not valid JSON — skipping", spotdl_file)
+                metrics.playlists_total += 1
+                continue
+
+            old_songs: list[dict] = sync_data if isinstance(sync_data, list) else []
+
+            logger.info("==> Syncing playlist: %s", name)
+            metrics.playlists_total += 1
+            output_dir = SPOTDL_DIR / name
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            try:
+                removed_urls, tracks_sent = sync_playlist(
+                    spotdl_file=spotdl_file,
+                    output_dir=output_dir,
+                    cookie_file=COOKIE_FILE,
+                    track_limit=remaining,
+                )
+            except Exception as exc:
+                reason = classify_failure(str(exc))
+                logger.error(
+                    "ERROR: spotdl sync failed for %s (reason=%s): %s", name, reason, exc
+                )
+                metrics.success = False
+                metrics.failure_reason = reason
+                if reason == "auth_youtube":
+                    metrics.cookies_expired = True
+                raise
+
+            metrics.tracks_downloaded += tracks_sent
+            if remaining is not None:
+                remaining -= tracks_sent
+
+            _collect_removals(pending_removals, removed_urls, old_songs, name)
+
+            # Brief pause between playlists — avoid hammering Spotify/YouTube APIs.
+            time.sleep(5)
+
+        _write_pending_removals(pending_removals, remove_sources)
+
+        logger.info("==> music-ingest complete. Run music-scan for local import and playlist generation.")
+
+    except SystemExit:
+        raise
+    except Exception:
+        if not metrics.failure_reason:
+            metrics.failure_reason = "unexpected_error"
+        metrics.success = False
+        logger.exception("music-ingest failed")
+        raise
+    finally:
+        metrics.duration_seconds = int(time.monotonic() - start)
+        metrics.push()

--- a/fetch/music_fetch/metrics.py
+++ b/fetch/music_fetch/metrics.py
@@ -1,0 +1,59 @@
+"""Prometheus text-format metric builders and Pushgateway push."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _gauge(name: str, value: int | float, labels: dict[str, str] | None = None) -> str:
+    label_str = ""
+    if labels:
+        pairs = ",".join(f'{k}="{v}"' for k, v in labels.items())
+        label_str = f"{{{pairs}}}"
+    return f"# TYPE {name} gauge\n{name}{label_str} {value}"
+
+
+def _push(body: str, job: str) -> None:
+    url = os.environ.get("PUSHGATEWAY_URL", "")
+    if not url:
+        return
+    endpoint = f"{url.rstrip('/')}/metrics/job/{job}"
+    try:
+        resp = requests.put(endpoint, data=(body + "\n").encode(), timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.warning("Failed to push metrics to %s: %s", endpoint, exc)
+
+
+@dataclass
+class IngestMetrics:
+    success: bool = True
+    duration_seconds: int = 0
+    playlists_total: int = 0
+    playlists_skipped: int = 0
+    playlists_deferred: int = 0
+    tracks_downloaded: int = 0
+    cookies_expired: bool = False
+    failure_reason: str = ""
+
+    def push(self) -> None:
+        lines = [
+            _gauge("music_ingest_last_run_success", int(self.success)),
+            _gauge("music_ingest_duration_seconds", self.duration_seconds),
+            _gauge("music_ingest_playlists_total", self.playlists_total),
+            _gauge("music_ingest_playlists_skipped_total", self.playlists_skipped),
+            _gauge("music_ingest_playlists_deferred_total", self.playlists_deferred),
+            _gauge("music_ingest_tracks_downloaded_total", self.tracks_downloaded),
+            _gauge("music_ingest_cookies_expired", int(self.cookies_expired)),
+        ]
+        if not self.success and self.failure_reason:
+            lines.append(
+                _gauge("music_ingest_last_failure_reason", 1, {"reason": self.failure_reason})
+            )
+        _push("\n".join(lines), "music_ingest")

--- a/fetch/music_fetch/spotdl_ops.py
+++ b/fetch/music_fetch/spotdl_ops.py
@@ -1,0 +1,182 @@
+"""spotdl operations implemented via the spotdl Python library.
+
+We use spotdl's internal classes directly instead of subprocess so that:
+- The snapshot diff is computed before downloading (no temp file needed).
+- Removed tracks are identified natively as a set difference.
+- We control sync_without_deleting explicitly (we do soft deletes via beets).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_spotdl_instance = None  # process-wide singleton (SpotifyClient + ProgressHandler can't be reinitialised)
+
+
+def _make_downloader_settings(
+    cookie_file: Path,
+    output_dir: Path | None = None,
+    save_file: Path | None = None,
+    sync_without_deleting: bool = True,
+) -> dict:
+    settings: dict = {
+        "cookie_file": str(cookie_file),
+        "format": "m4a",
+        "bitrate": "disable",
+        "overwrite": "skip",
+        "sync_without_deleting": sync_without_deleting,
+        "load_config": False,
+        "threads": 4,
+        "yt_dlp_args": "--js-runtimes node",
+    }
+    if output_dir is not None:
+        settings["output"] = str(output_dir)
+    if save_file is not None:
+        settings["save_file"] = str(save_file)
+    return settings
+
+
+def _make_spotdl(settings: dict):
+    """Return a Spotdl instance, creating it on the first call.
+
+    Both SpotifyClient and Rich's ProgressHandler are process-wide singletons
+    that cannot be reinitialised.  We keep one module-level instance and update
+    its Downloader settings on each call so per-playlist output_dir is respected.
+    """
+    global _spotdl_instance  # noqa: PLW0603
+    from spotdl import Spotdl  # noqa: PLC0415
+
+    if _spotdl_instance is not None:
+        _spotdl_instance.downloader.settings.update(settings)
+        return _spotdl_instance
+
+    client_id = os.environ["SPOTIFY_CLIENT_ID"]
+    client_secret = os.environ["SPOTIFY_CLIENT_SECRET"]
+    _spotdl_instance = Spotdl(
+        client_id=client_id,
+        client_secret=client_secret,
+        downloader_settings=settings,
+    )
+    return _spotdl_instance
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def save_playlist(url: str, spotdl_file: Path) -> None:
+    """Write a stub .spotdl sync file for a newly provisioned playlist.
+
+    Writes an empty songs list so the first sync treats all tracks as new and
+    downloads them.  The snapshot is populated by sync_playlist() as tracks are
+    downloaded; it records what has been downloaded, not what Spotify reports.
+    Idempotent: callers should check whether the file already exists before calling.
+    """
+    sync_data = {
+        "type": "sync",
+        "query": [url],
+        "songs": [],
+    }
+    with open(spotdl_file, "w", encoding="utf-8") as fh:
+        json.dump(sync_data, fh, indent=4, ensure_ascii=False)
+    logger.info("Provisioned stub .spotdl file for %s", spotdl_file.stem)
+
+
+def sync_playlist(
+    spotdl_file: Path,
+    output_dir: Path,
+    cookie_file: Path,
+    track_limit: int | None = None,
+) -> tuple[set[str], int]:
+    """Sync a playlist from its .spotdl file.
+
+    Downloads tracks new to the Spotify playlist, up to *track_limit* new
+    downloads this session.  When *track_limit* is None all new tracks are
+    downloaded.  Tracks deferred by the limit are excluded from the updated
+    snapshot so they re-appear as new on the next run.
+
+    Does NOT delete downloaded files for removed tracks — we handle that
+    separately via beets source-tag removal (soft delete).
+
+    Returns a tuple of:
+      - the set of Spotify track URLs removed from the playlist since the last sync
+      - the number of tracks sent to spotdl this session (tracks *sent*, not confirmed
+        completions — spotdl may download fewer if some are unavailable on YouTube)
+
+    Note on ordering: when *track_limit* is set, the batch is taken from the front of
+    the list returned by spotdl.search(), which for Spotify playlists is typically
+    playlist order (oldest-added first for Liked Songs).  This means the same leading
+    batch is retried each session until fully downloaded, then the next batch follows.
+    """
+    with open(spotdl_file, encoding="utf-8") as fh:
+        sync_data = json.load(fh)
+
+    if sync_data.get("type") != "sync":
+        raise ValueError(f"Not a valid spotdl sync file: {spotdl_file}")
+
+    old_urls: set[str] = {s["url"] for s in sync_data.get("songs", [])}
+    query: list[str] = sync_data["query"]
+
+    spotdl_obj = _make_spotdl(
+        _make_downloader_settings(
+            cookie_file=cookie_file,
+            output_dir=output_dir,
+            sync_without_deleting=True,
+        )
+    )
+
+    # Fetch current Spotify playlist state.
+    logger.info("Fetching current Spotify state for %s", spotdl_file.stem)
+    new_songs = spotdl_obj.search(query)
+    new_urls: set[str] = {s.url for s in new_songs}
+
+    removed_urls = old_urls - new_urls
+    if removed_urls:
+        logger.info("%d track(s) removed from Spotify playlist", len(removed_urls))
+
+    # Identify tracks not yet downloaded (absent from the previous snapshot).
+    truly_new = [s for s in new_songs if s.url not in old_urls]
+    total_new = len(truly_new)
+
+    if track_limit is not None and total_new > track_limit:
+        logger.info(
+            "Track budget: downloading %d of %d new track(s) this session (%d deferred to next run)",
+            track_limit,
+            total_new,
+            total_new - track_limit,
+        )
+        truly_new = truly_new[:track_limit]
+
+    # Download only the new batch; existing tracks are already on disk (overwrite=skip).
+    results = spotdl_obj.download_songs(truly_new)
+
+    # Only persist songs that were actually downloaded (path is not None).
+    # Songs where spotdl returned None failed silently — exclude them from the snapshot
+    # so they are retried as 'truly_new' on the next run.
+    downloaded_urls = {song.url for song, path in results if path is not None}
+    songs_to_write = [s for s in new_songs if s.url in old_urls or s.url in downloaded_urls]
+
+    with open(spotdl_file, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "type": "sync",
+                "query": query,
+                "songs": [s.json for s in songs_to_write],
+            },
+            fh,
+            indent=4,
+            ensure_ascii=False,
+        )
+
+    return removed_urls, len(truly_new)
+
+
+def find_track_in_snapshot(snapshot: list[dict], url: str) -> dict | None:
+    """Return the first song entry in a .spotdl snapshot that matches *url*."""
+    return next((t for t in snapshot if t.get("url") == url), None)

--- a/fetch/pyproject.toml
+++ b/fetch/pyproject.toml
@@ -9,11 +9,11 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]
-music-ingest = "pipeline.cli:main"
+music-ingest = "music_fetch.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["pipeline*"]
+include = ["music_fetch*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/fetch/tests/test_config.py
+++ b/fetch/tests/test_config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pipeline.config import PlaylistConfig, load_playlists
+from music_fetch.config import PlaylistConfig, load_playlists
 
 
 def write_conf(tmp_path: Path, content: str) -> Path:

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from pipeline.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, _write_pending_removals
-from pipeline.spotdl_ops import find_track_in_snapshot
+from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, _write_pending_removals
+from music_fetch.spotdl_ops import find_track_in_snapshot
 
 
 # ---------------------------------------------------------------------------
@@ -400,7 +400,7 @@ def test_reconcile_provisions_new_playlist(tmp_path: Path) -> None:
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch.object(ingest, "COOKIE_FILE", tmp_path / "cookies.txt"), \
-         mock.patch("pipeline.ingest.save_playlist") as mock_save:
+         mock.patch("music_fetch.ingest.save_playlist") as mock_save:
         result = _reconcile_playlists()
 
     mock_save.assert_called_once()
@@ -422,7 +422,7 @@ def test_reconcile_skips_existing_spotdl(tmp_path: Path) -> None:
 
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.ingest.save_playlist") as mock_save:
+         mock.patch("music_fetch.ingest.save_playlist") as mock_save:
         result = _reconcile_playlists()
 
     mock_save.assert_not_called()
@@ -441,7 +441,7 @@ def test_reconcile_creates_nosync_sentinel(tmp_path: Path) -> None:
 
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.ingest.save_playlist"):
+         mock.patch("music_fetch.ingest.save_playlist"):
         _reconcile_playlists()
 
     assert (spotdl_dir / "frozen.nosync").exists()
@@ -460,7 +460,7 @@ def test_reconcile_removes_nosync_sentinel(tmp_path: Path) -> None:
 
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.ingest.save_playlist"):
+         mock.patch("music_fetch.ingest.save_playlist"):
         _reconcile_playlists()
 
     assert not (spotdl_dir / "mypl.nosync").exists()
@@ -483,7 +483,7 @@ def test_reconcile_detects_removed_playlist(tmp_path: Path) -> None:
 
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.ingest.save_playlist"):
+         mock.patch("music_fetch.ingest.save_playlist"):
         result = _reconcile_playlists()
 
     assert result == ["gone"]
@@ -567,7 +567,7 @@ def test_reconcile_deletes_nosync_for_removed_playlist(tmp_path: Path) -> None:
 
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.ingest.save_playlist"):
+         mock.patch("music_fetch.ingest.save_playlist"):
         result = _reconcile_playlists()
 
     assert result == ["gone"]

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -244,7 +244,7 @@ def test_collect_removals_no_removed_urls() -> None:
 
 def test_write_pending_removals_creates_file(tmp_path: Path) -> None:
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
@@ -259,7 +259,7 @@ def test_write_pending_removals_creates_file(tmp_path: Path) -> None:
 
 def test_write_pending_removals_with_remove_sources(tmp_path: Path) -> None:
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     tracks = [{"title": "Song A", "artist": "Artist 1", "source": "pl-1"}]
@@ -275,7 +275,7 @@ def test_write_pending_removals_with_remove_sources(tmp_path: Path) -> None:
 def test_write_pending_removals_appends_to_existing(tmp_path: Path) -> None:
     """The append-safe merge is the key correctness guarantee of the cross-container handoff."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     existing = {"tracks": [{"title": "Song A", "artist": "Artist 1", "source": "playlist-1"}], "remove_sources": []}
@@ -293,7 +293,7 @@ def test_write_pending_removals_appends_to_existing(tmp_path: Path) -> None:
 def test_write_pending_removals_merges_remove_sources(tmp_path: Path) -> None:
     """remove_sources from multiple fetch runs are accumulated."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     existing = {"tracks": [], "remove_sources": ["old-playlist"]}
@@ -309,7 +309,7 @@ def test_write_pending_removals_merges_remove_sources(tmp_path: Path) -> None:
 def test_write_pending_removals_merges_with_old_format_file(tmp_path: Path) -> None:
     """Old list-format file is read and merged into the new dict format."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     old_format = [{"title": "Song A", "artist": "Artist 1", "source": "playlist-1"}]
@@ -327,7 +327,7 @@ def test_write_pending_removals_merges_with_old_format_file(tmp_path: Path) -> N
 def test_write_pending_removals_recovers_from_corrupt_file(tmp_path: Path) -> None:
     """Corrupt existing file is discarded; new entries are still written."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     fake_path.write_text("not valid json", encoding="utf-8")
@@ -344,7 +344,7 @@ def test_write_pending_removals_recovers_from_corrupt_file(tmp_path: Path) -> No
 def test_write_pending_removals_noop_when_empty(tmp_path: Path) -> None:
     """No file created when there are no pending removals."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
@@ -356,7 +356,7 @@ def test_write_pending_removals_noop_when_empty(tmp_path: Path) -> None:
 def test_write_pending_removals_noop_with_only_empty_remove_sources(tmp_path: Path) -> None:
     """No file created when remove_sources is an empty list."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     fake_path = tmp_path / ".pending-removals.json"
     with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
@@ -379,7 +379,7 @@ def _make_conf(tmp_path: Path, lines: list[str]) -> Path:
 def test_reconcile_no_conf(tmp_path: Path) -> None:
     """Returns empty list if playlists.conf does not exist."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     missing = tmp_path / "playlists.conf"
     with mock.patch.object(ingest, "CONF_PATH", missing):
@@ -391,7 +391,7 @@ def test_reconcile_no_conf(tmp_path: Path) -> None:
 def test_reconcile_provisions_new_playlist(tmp_path: Path) -> None:
     """New playlist entry → save_playlist is called; .spotdl file is created."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -413,7 +413,7 @@ def test_reconcile_provisions_new_playlist(tmp_path: Path) -> None:
 def test_reconcile_skips_existing_spotdl(tmp_path: Path) -> None:
     """Playlist whose .spotdl already exists is not re-provisioned."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -432,7 +432,7 @@ def test_reconcile_skips_existing_spotdl(tmp_path: Path) -> None:
 def test_reconcile_creates_nosync_sentinel(tmp_path: Path) -> None:
     """Playlist marked nosync in config → sentinel file is created."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -450,7 +450,7 @@ def test_reconcile_creates_nosync_sentinel(tmp_path: Path) -> None:
 def test_reconcile_removes_nosync_sentinel(tmp_path: Path) -> None:
     """Playlist with nosync removed from config → sentinel file is deleted."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -469,7 +469,7 @@ def test_reconcile_removes_nosync_sentinel(tmp_path: Path) -> None:
 def test_reconcile_detects_removed_playlist(tmp_path: Path) -> None:
     """Playlist on disk but absent from config → queued for removal, files deleted."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -499,7 +499,7 @@ def test_reconcile_detects_removed_playlist(tmp_path: Path) -> None:
 
 def test_preflight_missing_cookies(tmp_path: Path) -> None:
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     with mock.patch.object(ingest, "COOKIE_FILE", tmp_path / "cookies.txt"), \
          mock.patch.dict("os.environ", {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}):
@@ -510,7 +510,7 @@ def test_preflight_missing_cookies(tmp_path: Path) -> None:
 
 def test_preflight_missing_spotify_env(tmp_path: Path) -> None:
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     cookie_file = tmp_path / "cookies.txt"
     cookie_file.touch()
@@ -525,7 +525,7 @@ def test_preflight_missing_spotify_env(tmp_path: Path) -> None:
 def test_preflight_disk_full(tmp_path: Path) -> None:
     import shutil
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     cookie_file = tmp_path / "cookies.txt"
     cookie_file.touch()
@@ -541,7 +541,7 @@ def test_preflight_disk_full(tmp_path: Path) -> None:
 
 def test_preflight_ok(tmp_path: Path) -> None:
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     cookie_file = tmp_path / "cookies.txt"
     cookie_file.touch()
@@ -557,7 +557,7 @@ def test_preflight_ok(tmp_path: Path) -> None:
 def test_reconcile_deletes_nosync_for_removed_playlist(tmp_path: Path) -> None:
     """Removed playlist's .nosync sentinel is also deleted."""
     import unittest.mock as mock
-    from pipeline import ingest
+    from music_fetch import ingest
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()

--- a/fetch/tests/test_metrics.py
+++ b/fetch/tests/test_metrics.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pipeline.metrics import IngestMetrics, _gauge
+from music_fetch.metrics import IngestMetrics, _gauge
 
 
 # ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ def test_gauge_float_value() -> None:
 
 def test_ingest_metrics_success_body(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))
 
     m = IngestMetrics(success=True, duration_seconds=120, playlists_total=3, playlists_skipped=1)
     m.push()
@@ -46,7 +46,7 @@ def test_ingest_metrics_success_body(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_ingest_metrics_failure_includes_reason(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))
 
     m = IngestMetrics(success=False, failure_reason="rate_limited")
     m.push()
@@ -58,14 +58,14 @@ def test_ingest_metrics_failure_includes_reason(monkeypatch: pytest.MonkeyPatch)
 
 def test_push_job_label_ingest(monkeypatch: pytest.MonkeyPatch) -> None:
     jobs: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: jobs.append(job))
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: jobs.append(job))
     IngestMetrics().push()
     assert jobs == ["music_ingest"]
 
 
 def test_ingest_metrics_tracks_downloaded(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))
 
     m = IngestMetrics(tracks_downloaded=42)
     m.push()
@@ -75,7 +75,7 @@ def test_ingest_metrics_tracks_downloaded(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_ingest_metrics_cookies_expired_true(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))
 
     m = IngestMetrics(cookies_expired=True)
     m.push()
@@ -85,7 +85,7 @@ def test_ingest_metrics_cookies_expired_true(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_ingest_metrics_cookies_expired_false_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))
 
     IngestMetrics().push()
 

--- a/fetch/tests/test_spotdl_ops.py
+++ b/fetch/tests/test_spotdl_ops.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from pipeline.spotdl_ops import save_playlist, sync_playlist
+from music_fetch.spotdl_ops import save_playlist, sync_playlist
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +73,7 @@ def test_sync_playlist_after_stub_downloads_all_songs(tmp_path: Path) -> None:
     mock_spotdl.search.return_value = songs
     mock_spotdl.download_songs.return_value = [(s, Path(f"/tmp/{i}.m4a")) for i, s in enumerate(songs)]
 
-    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
         removed_urls, tracks_sent = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
@@ -118,7 +118,7 @@ def test_sync_playlist_second_run_skips_known_songs(tmp_path: Path) -> None:
     mock_spotdl.search.return_value = new_songs
     mock_spotdl.download_songs.return_value = [(s, Path(f"/tmp/{i}.m4a")) for i, s in enumerate(new_only)]
 
-    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
         removed_urls, tracks_sent = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
@@ -164,7 +164,7 @@ def test_sync_playlist_detects_removed_tracks(tmp_path: Path) -> None:
     mock_spotdl.search.return_value = [_make_mock_song("https://open.spotify.com/track/A")]
     mock_spotdl.download_songs.return_value = []  # nothing new to download
 
-    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
         removed_urls, tracks_sent = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
@@ -199,7 +199,7 @@ def test_sync_playlist_failed_downloads_not_persisted(tmp_path: Path) -> None:
         (songs[3], None),
     ]
 
-    with mock.patch("pipeline.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
         removed_urls, tracks_sent = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,

--- a/scan/Dockerfile
+++ b/scan/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
 
 # Install the pipeline package — entry points land in /usr/local/bin/
-COPY pipeline/ /app/pipeline/
+COPY music_scan/ /app/music_scan/
 COPY pyproject.toml /app/pyproject.toml
 RUN pip install --no-cache-dir -e /app
 

--- a/scan/music_scan/cli.py
+++ b/scan/music_scan/cli.py
@@ -1,0 +1,24 @@
+"""Console entry points for the scan container."""
+
+from __future__ import annotations
+
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S%z",
+)
+
+
+def main() -> None:
+    """Entry point: music-scan."""
+    try:
+        from music_scan.scan import run  # noqa: PLC0415
+    except ImportError as exc:
+        import sys
+        print(f"[music-scan] Failed to import pipeline: {exc}. Check container installation.", file=sys.stderr)
+        sys.exit(1)
+    run()
+
+

--- a/scan/music_scan/library.py
+++ b/scan/music_scan/library.py
@@ -1,0 +1,73 @@
+"""Thin wrapper around the beets Library API for the operations we need."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from beets.library import Item
+
+logger = logging.getLogger(__name__)
+
+LIBRARY_DB = Path("/root/.config/beets/library.db")
+
+
+class MusicLibrary:
+    """Context-manager wrapper around beets.library.Library."""
+
+    def __init__(self, db_path: Path = LIBRARY_DB) -> None:
+        from beets.library import Library  # deferred — not available in tests without beets
+
+        self._lib = Library(str(db_path))
+
+    def __enter__(self) -> "MusicLibrary":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self._lib._close()
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    def items_by_source(self, source: str) -> list["Item"]:
+        """All items whose source flexible-attribute matches *source*."""
+        return list(self._lib.items(f"source:{source}"))
+
+    def items_added_since(self, since: float) -> list[tuple[str, str]]:
+        """Return (title, artist) for items added to the library after *since* (Unix timestamp)."""
+        return [
+            (item.title or "", item.artist or item.albumartist or "")
+            for item in self._lib.items()
+            if (item.added or 0) >= since
+        ]
+
+    def paths_by_source(self, source: str) -> list[Path]:
+        """File paths for all items with the given source tag."""
+        items = self.items_by_source(source)
+        return [
+            Path(item.path.decode() if isinstance(item.path, bytes) else item.path)
+            for item in items
+        ]
+
+    # ------------------------------------------------------------------
+    # Modification helpers
+    # ------------------------------------------------------------------
+
+    def clear_source_tag(self, title: str, artist: str, source: str) -> bool:
+        """Clear the source tag on items matching title + artist + source.
+
+        Returns True if at least one item was modified.
+        Matching is done with beets' query syntax (substring by default).
+        """
+        query = f"title:{title} artist:{artist} source:{source}"
+        items = list(self._lib.items(query))
+        if not items:
+            return False
+        for item in items:
+            item["source"] = ""
+            item.store()
+        logger.debug("Cleared source tag on %d item(s) matching %r", len(items), query)
+        return True

--- a/scan/music_scan/metrics.py
+++ b/scan/music_scan/metrics.py
@@ -1,0 +1,55 @@
+"""Prometheus text-format metric builders and Pushgateway push."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _gauge(name: str, value: int | float, labels: dict[str, str] | None = None) -> str:
+    label_str = ""
+    if labels:
+        pairs = ",".join(f'{k}="{v}"' for k, v in labels.items())
+        label_str = f"{{{pairs}}}"
+    return f"# TYPE {name} gauge\n{name}{label_str} {value}"
+
+
+def _push(body: str, job: str) -> None:
+    url = os.environ.get("PUSHGATEWAY_URL", "")
+    if not url:
+        return
+    endpoint = f"{url.rstrip('/')}/metrics/job/{job}"
+    try:
+        resp = requests.put(endpoint, data=(body + "\n").encode(), timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.warning("Failed to push metrics to %s: %s", endpoint, exc)
+
+
+@dataclass
+class ScanMetrics:
+    success: bool = True
+    duration_seconds: int = 0
+    quarantined_tracks: int = 0
+    tracks_imported: int = 0
+    tracks_removed: int = 0
+    failure_reason: str = ""
+
+    def push(self) -> None:
+        lines = [
+            _gauge("music_scan_last_run_success", int(self.success)),
+            _gauge("music_scan_duration_seconds", self.duration_seconds),
+            _gauge("music_scan_quarantined_tracks_total", self.quarantined_tracks),
+            _gauge("music_scan_tracks_imported_total", self.tracks_imported),
+            _gauge("music_scan_tracks_removed_total", self.tracks_removed),
+        ]
+        if not self.success and self.failure_reason:
+            lines.append(
+                _gauge("music_scan_last_failure_reason", 1, {"reason": self.failure_reason})
+            )
+        _push("\n".join(lines), "music_scan")

--- a/scan/music_scan/music_pipeline.py
+++ b/scan/music_scan/music_pipeline.py
@@ -1,0 +1,259 @@
+"""Beets plugin: tag-on-import and conditional duplicate replacement.
+
+Responsibilities
+----------------
+1. **tag_source_on_created** (``import_task_created``): every track imported
+   from the spotdl inbox gets two flexible attributes:
+
+   * ``source=<playlist>``  — playlist membership; drives .m3u generation,
+     ``clear_source_tag``, and ``music-remove``.  All existing pipeline code
+     reads this unchanged.
+   * ``via=spotdl``          — import origin; used *only* to decide whether a
+     duplicate can be replaced safely.  Never inherited.
+
+   Fires from ``handle_created()`` during ``read_tasks`` — always, regardless
+   of autotag mode — while ``item.path`` still points to the inbox file.
+   Handles both singleton (``task.item``) and album (``task.items``) import
+   tasks.
+
+   Caches both ``filename → playlist`` and ``title → playlist`` in
+   ``_pending_sources`` for step 1a.
+
+1a. **tag_source_on_stored** (``item_imported``): re-applies ``source=`` and
+    ``via=`` after the item is fully persisted, then calls ``item.store()``.
+    Two things can discard the flex attributes between steps 1 and 1a:
+    (a) beets' dirty-field tracking is reset during candidate lookup, so
+    flex attributes set in memory at ``import_task_created`` are not marked
+    dirty for the eventual ``item.add(lib)`` call; and
+    (b) beets renames the file on import (spotdl names ``Artist - Title.m4a``;
+    beets renames to ``NN - Title.m4a``), so the inbox filename no longer
+    matches ``item.path`` at ``item_imported`` time.  The title-based key
+    survives both.  This hook guarantees the tags land in the database on
+    clean first-time imports.
+
+2. **Duplicate protection** (``import_task_choice``): when duplicates exist in
+   the library for the incoming track:
+
+   * Any duplicate has no ``via=spotdl`` (manually imported) → skip the
+     incoming file AND delete it from the inbox so it does not get
+     re-attempted on every subsequent beet-import run.
+   * All duplicates have ``via=spotdl`` → do nothing; ``duplicate_action:
+     remove`` in config.yaml handles removal automatically.
+
+   Only fires when ``autotag=True`` (production). In ASIS mode
+   (``autotag=False``), ``import_asis`` calls ``_resolve_duplicates``
+   directly using ``config duplicate_action``.
+
+Note
+----
+``import_task_start`` is inside ``lookup_candidates`` and only fires when
+``autotag=True``; it is never emitted in ASIS mode.  ``import_task_created``
+is the earliest hook that works in both modes.
+
+beets does not expose an ``import_task_duplicate_action`` event.
+Duplicate handling must be done inside ``import_task_choice``, which fires
+just before ``_resolve_duplicates()`` is called by the importer pipeline.
+
+Known limitations
+-----------------
+**PVC-loss recovery:** after a wiped database, no existing items exist so no
+duplicate check fires. After the rebuild completes all tracks will carry
+``via=spotdl`` for future runs. No manual intervention needed.
+"""
+
+from pathlib import Path
+
+from beets import importer as beets_importer
+from beets import library as beets_library
+from beets.plugins import BeetsPlugin
+
+# The two locations where spotdl downloads land at beet-import time.
+# 1. Main inbox: downloaded files sit here until beet import runs.
+SPOTDL_INBOX = Path("/root/Music/inbox/spotdl")
+# 2. ASIS staging: files that failed autotag are quarantined, then
+#    _move_asis_eligible() copies them into a per-run temp dir under /tmp/
+#    preserving the spotdl/<playlist>/ subdirectory structure.
+ASIS_STAGING_ROOT = Path("/tmp")
+
+# Actions that indicate the task will actually be applied to the library.
+# Matches the guard used by beets' own _resolve_duplicates().
+_WILL_APPLY = (
+    beets_importer.Action.APPLY,
+    beets_importer.Action.ASIS,
+    beets_importer.Action.RETAG,
+)
+
+
+def _playlist_from_path(path: str | bytes) -> str | None:
+    """Return the playlist name for *path*, or None if not recognisable.
+
+    Checks two known locations in order:
+      1. Main inbox:    /root/Music/inbox/spotdl/<playlist>/<file>
+      2. ASIS staging:  /tmp/asis-staging-X/spotdl/<playlist>/<file>
+         (the staging dir name is random, but spotdl/ is always the first
+         subdir of the playlist tree relative to ASIS_STAGING_ROOT)
+    """
+    if isinstance(path, bytes):
+        path = path.decode()
+    p = Path(path)
+
+    # 1. Main inbox — spotdl/<playlist>/ is the root itself.
+    try:
+        return p.relative_to(SPOTDL_INBOX).parts[0]
+    except (ValueError, IndexError):
+        pass
+
+    # 2. ASIS staging — /tmp/<staging-dir>/spotdl/<playlist>/<file>
+    try:
+        after_tmp = p.relative_to(ASIS_STAGING_ROOT)
+        # after_tmp.parts: ('<staging-dir>', 'spotdl', '<playlist>', '<file>')
+        idx = after_tmp.parts.index("spotdl")
+        return after_tmp.parts[idx + 1]
+    except (ValueError, IndexError):
+        pass
+
+    return None
+
+
+def _all_via_spotdl(duplicates: list) -> bool:
+    """Return True if every duplicate in *duplicates* carries via=spotdl."""
+    return all((item.get("via") or "") == "spotdl" for item in duplicates)
+
+
+def _items_from_task(task) -> list:
+    """Return the list of items for a task (singleton or album)."""
+    if getattr(task, "item", None) is not None:
+        return [task.item]
+    return list(getattr(task, "items", None) or [])
+
+
+class MusicPipelinePlugin(BeetsPlugin):
+    def __init__(self):
+        super().__init__("music_pipeline")
+        # Keys: inbox filename OR normalised title → playlist name.
+        # Populated at import_task_created, consumed at item_imported.
+        # Two keys per track because beets renames the file on import
+        # (spotdl names "Artist - Title.m4a"; beets renames to "NN - Title.m4a"),
+        # so the filename key no longer matches at item_imported time.
+        # The title key survives both the rename and MB autotag metadata replacement.
+        self._pending_sources: dict[str, str] = {}
+        self.register_listener("import_task_created", self.tag_source_on_created)
+        self.register_listener("item_imported", self.tag_source_on_stored)
+        self.register_listener("import_task_choice", self.handle_duplicates)
+
+    def tag_source_on_created(self, session, task):
+        """Tag incoming tracks with source= and via= at task creation.
+
+        Fires from handle_created() during read_tasks — always, regardless of
+        autotag mode — while item.path still points to the inbox file (before
+        any pipeline stage runs).
+
+        Caches both the inbox filename and the normalised title in
+        _pending_sources so tag_source_on_stored can re-apply the tags after
+        MusicBrainz autotag may have discarded them and beets has renamed the
+        file.
+        """
+        for item in _items_from_task(task):
+            playlist = _playlist_from_path(item.path)
+            if playlist is None:
+                continue
+            item["source"] = playlist
+            item["via"] = "spotdl"
+            path = item.path.decode() if isinstance(item.path, bytes) else item.path
+            self._pending_sources[Path(path).name] = playlist
+            title = (item.title or "").lower()
+            if title:
+                self._pending_sources[title] = playlist
+            self._log.debug(
+                "tagged incoming track source={} via=spotdl: {}", playlist, item.path
+            )
+
+    def tag_source_on_stored(self, lib, item):
+        """Re-apply source= and via= after the item is persisted to the library.
+
+        Fires from item_imported, after autotag and item.store() have run.
+        MusicBrainz autotag can replace the item's metadata dict wholesale and
+        beets renames the file, both of which discard the flex attributes set
+        earlier by tag_source_on_created.  We try the post-rename filename
+        first (handles no-rename edge cases), then fall back to the normalised
+        title (the common case after a move-import).
+        """
+        path = item.path.decode() if isinstance(item.path, bytes) else item.path
+        title = (item.title or "").lower()
+        playlist = self._pending_sources.pop(Path(path).name, None)
+        if playlist is not None:
+            # Matched on filename — also clean the title key to avoid stale entries.
+            if title:
+                self._pending_sources.pop(title, None)
+        elif title:
+            playlist = self._pending_sources.pop(title, None)
+            # The original spotdl inbox filename key cannot be recovered from
+            # item.path (which is now the renamed library path), so it may
+            # remain in _pending_sources.  That is harmless: _pending_sources
+            # is session-scoped and is GC'd when the import session ends.
+        if playlist is None:
+            return
+        item["source"] = playlist
+        item["via"] = "spotdl"
+        item.store()
+        self._log.debug(
+            "persisted source={} via=spotdl on stored item: {}", playlist, item.path
+        )
+
+    def handle_duplicates(self, session, task):
+        """Protect manually-imported tracks from spotdl overwrites.
+
+        Fires from user_query (autotag=True only). In ASIS mode
+        (autotag=False) beets applies duplicate_action from config directly.
+        """
+        items = _items_from_task(task)
+
+        # Only check duplicates for tasks that will be applied to the library.
+        # Mirrors the guard in beets' own _resolve_duplicates().
+        if not items or task.choice_flag not in _WILL_APPLY:
+            return
+
+        try:
+            found = task.find_duplicates(session.lib)
+        except Exception as exc:
+            self._log.warning("could not check for duplicates: {}", exc)
+            return
+
+        if not found:
+            return
+
+        # Flatten album duplicates to individual items for via= inspection.
+        dup_items = []
+        for dup in found:
+            if isinstance(dup, beets_library.Album):
+                dup_items.extend(dup.items())
+            else:
+                dup_items.append(dup)
+
+        if _all_via_spotdl(dup_items):
+            # All spotdl-sourced — let duplicate_action: remove in config
+            # handle removal automatically.
+            self._log.debug(
+                "spotdl-only duplicate(s) found; deferring to config duplicate_action"
+            )
+            return
+
+        # At least one manually-imported copy — protect it.
+        # Delete the incoming spotdl file from the inbox so it doesn't
+        # linger and get re-attempted on every beet import run.
+        for item in items:
+            path = item.path if isinstance(item.path, str) else item.path.decode()
+            try:
+                Path(path).unlink(missing_ok=True)
+                self._log.debug(
+                    "discarded spotdl inbox file protected by"
+                    " non-spotdl duplicate: {}",
+                    path,
+                )
+            except OSError as exc:
+                self._log.warning(
+                    "could not remove skipped inbox file {}: {}", path, exc
+                )
+
+        task.set_choice(beets_importer.Action.SKIP)
+        self._log.debug("skipping import: manual duplicate exists in library")

--- a/scan/music_scan/navidrome.py
+++ b/scan/music_scan/navidrome.py
@@ -1,0 +1,49 @@
+"""Notify Navidrome to trigger a library rescan via the Subsonic API."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def trigger_scan() -> None:
+    """POST a startScan request to Navidrome if NAVIDROME_URL is configured.
+
+    Reads NAVIDROME_URL, NAVIDROME_USER, and NAVIDROME_PASSWORD from the
+    environment. If any are absent, logs a debug message and returns silently —
+    the caller does not need to guard against a missing configuration.
+    """
+    url = os.environ.get("NAVIDROME_URL", "")
+    user = os.environ.get("NAVIDROME_USER", "")
+    password = os.environ.get("NAVIDROME_PASSWORD", "")
+
+    if not url:
+        return
+
+    if not user or not password:
+        logger.warning("NAVIDROME_URL is set but NAVIDROME_USER or NAVIDROME_PASSWORD is missing — skipping rescan")
+        return
+
+    endpoint = f"{url.rstrip('/')}/rest/startScan.view"
+    params = {
+        "u": user,
+        "p": password,
+        "v": "1.8.0",
+        "c": "music-pipeline",
+        "f": "json",
+    }
+    try:
+        resp = requests.get(endpoint, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        status = data.get("subsonic-response", {}).get("status")
+        if status != "ok":
+            logger.warning("Navidrome rescan returned non-ok status: %s", data)
+        else:
+            logger.info("==> Navidrome library rescan triggered")
+    except requests.RequestException as exc:
+        logger.warning("Failed to trigger Navidrome rescan: %s", exc)

--- a/scan/music_scan/process.py
+++ b/scan/music_scan/process.py
@@ -1,0 +1,96 @@
+"""Subprocess helpers: run beet commands with SIGTERM forwarding."""
+
+from __future__ import annotations
+
+import logging
+import signal
+import subprocess
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+logger = logging.getLogger(__name__)
+
+IMPORT_LOG = Path("/root/.config/beets/import.log")
+
+
+@contextmanager
+def _forward_sigterm(proc: subprocess.Popen) -> Generator[None, None, None]:
+    """Context manager: while active, SIGTERM is forwarded to *proc*."""
+
+    def _handler(sig: int, frame: object) -> None:
+        logger.info("Shutdown signal received — forwarding to child process (pid %d)", proc.pid)
+        proc.send_signal(signal.SIGTERM)
+
+    old = signal.signal(signal.SIGTERM, _handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, old)
+
+
+def _watch_for_skips(log_path: Path, start_pos: int, skip_limit: int,
+                     proc: subprocess.Popen, stop: threading.Event) -> None:
+    """Poll the beets import log; SIGTERM *proc* after *skip_limit* new skips."""
+    skip_count = 0
+    while not stop.is_set():
+        try:
+            with open(log_path) as f:
+                f.seek(start_pos)
+                new_lines = f.read().splitlines()
+            new_skips = sum(1 for l in new_lines if l.startswith("skip "))
+            if new_skips > skip_count:
+                skip_count = new_skips
+                logger.info("Skip count: %d / %d limit", skip_count, skip_limit)
+            if skip_count >= skip_limit:
+                logger.warning("Skip limit %d reached — terminating beet import early", skip_limit)
+                proc.terminate()
+                return
+        except FileNotFoundError:
+            pass
+        time.sleep(0.5)
+
+
+def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool = False) -> None:
+    """Run ``beet import --quiet <inbox_dir>``, forwarding SIGTERM to beet.
+
+    Args:
+        skip_limit: If set, terminate beet after this many skipped tracks (for threshold
+                    testing without waiting through a full library run).
+        asis: If True, pass ``--asis`` to import using existing embedded tags without
+              MusicBrainz lookups.
+    """
+    cmd = ["beet", "import", "--quiet"]
+    if asis:
+        cmd.append("-A")
+    cmd.append(str(inbox_dir))
+    logger.debug("Running: %s", " ".join(cmd))
+
+    log_start = IMPORT_LOG.stat().st_size if IMPORT_LOG.exists() else 0
+    proc = subprocess.Popen(cmd)
+
+    stop = threading.Event()
+    if skip_limit is not None:
+        t = threading.Thread(
+            target=_watch_for_skips,
+            args=(IMPORT_LOG, log_start, skip_limit, proc, stop),
+            daemon=True,
+        )
+        t.start()
+
+    with _forward_sigterm(proc):
+        rc = proc.wait()
+    stop.set()
+
+    # rc=-15 (SIGTERM) is expected when skip_limit fires — not an error
+    if rc not in (0, -15):
+        raise subprocess.CalledProcessError(rc, cmd)
+
+
+def run_beet_update() -> None:
+    """Run ``beet update`` (non-fatal on failure)."""
+    result = subprocess.run(["beet", "update"], check=False)
+    if result.returncode != 0:
+        logger.warning("beet update exited with code %d (non-fatal)", result.returncode)

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -1,0 +1,298 @@
+"""music-scan: import inbox → beets, refresh metadata, regenerate .m3u playlists,
+push Prometheus metrics.
+
+Called frequently (every 5 min by default) and also after music-ingest completes.
+No Spotify or YouTube calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from music_scan.library import MusicLibrary
+from music_scan.metrics import ScanMetrics
+from music_scan.navidrome import trigger_scan
+from music_scan.process import run_beet_import, run_beet_update
+
+logger = logging.getLogger(__name__)
+
+AUDIO_EXTS = {".mp3", ".flac", ".ogg", ".opus", ".m4a", ".aac", ".wav", ".wma", ".aiff", ".ape", ".mpc"}
+SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
+QUARANTINE = Path("/root/Music/quarantine")
+PLAYLISTS = Path("/root/Music/playlists")
+INBOX = Path("/root/Music/inbox")
+LIBRARY_DB = Path("/root/.config/beets/library.db")
+PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
+
+
+_STOP_WORDS = frozenset({"the", "and", "for", "feat", "ft", "vs", "with", "a", "an", "of", "in", "on"})
+
+
+def _name_words(s: str) -> frozenset[str]:
+    """Normalise a track/filename string to a set of significant lowercase words."""
+    words = re.sub(r"[^\w\s]", " ", s.lower()).split()
+    return frozenset(w for w in words if len(w) > 2 and w not in _STOP_WORDS)
+
+
+def _snapshot_inbox(inbox: Path) -> list[str]:
+    """Return sorted list of audio filename stems currently in the inbox tree."""
+    return sorted(
+        f.stem for f in inbox.rglob("*")
+        if f.is_file() and f.suffix.lower() in AUDIO_EXTS
+    )
+
+
+def _check_import_names(inbox_stems: list[str], imported: list[tuple[str, str]]) -> None:
+    """Compare imported track names against the pre-import inbox snapshot.
+
+    Flags tracks whose title+artist shares less than 40% Jaccard word-overlap
+    with the closest matching inbox filename — a signal that beets may have
+    applied a wildly wrong match.
+    """
+    if not inbox_stems or not imported:
+        return
+
+    inbox_word_sets = [_name_words(s) for s in inbox_stems]
+
+    flagged = []
+    for title, artist in imported:
+        lib_words = _name_words(f"{title} {artist}")
+        if not lib_words:
+            continue
+        best = max(
+            (len(lib_words & iws) / max(len(lib_words | iws), 1) for iws in inbox_word_sets),
+            default=0.0,
+        )
+        if best < 0.4:
+            flagged.append((title, artist, best))
+
+    if flagged:
+        logger.warning("==> %d imported track(s) look unlike anything in the inbox (possible bad match):", len(flagged))
+        for title, artist, score in sorted(flagged, key=lambda x: x[2]):
+            logger.warning("  !! %s — %s  (best inbox overlap: %.0f%%)", title, artist, score * 100)
+    else:
+        logger.info("==> Name check OK: all %d imported tracks resemble their inbox source files", len(imported))
+
+
+def _count_quarantine() -> int:
+    if not QUARANTINE.exists():
+        return 0
+    return sum(1 for _ in QUARANTINE.rglob("*") if _.is_file())
+
+
+def _quarantine_inbox_leftovers() -> int:
+    """Move any audio files still anywhere in the inbox tree to quarantine.
+
+    After ``beet import`` has processed everything it can, un-matched audio
+    files remain in the inbox.  We move them to quarantine for manual review,
+    preserving the relative path so it's clear which playlist/album they came
+    from.  Returns the count of files moved.
+    """
+    QUARANTINE.mkdir(parents=True, exist_ok=True)
+    moved = 0
+    for f in INBOX.rglob("*"):
+        if f.is_file() and f.suffix.lower() in AUDIO_EXTS:
+            dest = QUARANTINE / f.relative_to(INBOX)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(f), dest)
+            moved += 1
+    return moved
+
+
+def _process_pending_removals() -> int:
+    """Clear beets source tags for tracks/playlists removed by the fetch container.
+
+    Reads .pending-removals.json from the shared volume, processes each entry,
+    then deletes the file.  Returns the number of entries processed.
+
+    Supports both formats:
+    - Old (list): [{title, artist, source}, ...]
+    - New (dict): {tracks: [{title, artist, source}], remove_sources: [name, ...]}
+    """
+    if not PENDING_REMOVALS.exists():
+        return 0
+
+    content = PENDING_REMOVALS.read_text(encoding="utf-8")
+    PENDING_REMOVALS.unlink()
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        logger.error(
+            "Discarded malformed .pending-removals.json — source-tag cleanup skipped. "
+            "Manually run `beet modify source= source:<name>` for affected playlists."
+        )
+        return 0
+
+    # Support old list format for backward compatibility.
+    if isinstance(data, list):
+        tracks: list[dict] = data
+        remove_sources: list[str] = []
+    else:
+        tracks = data.get("tracks", [])
+        remove_sources = data.get("remove_sources", [])
+
+    if not tracks and not remove_sources:
+        return 0
+
+    logger.info(
+        "==> Processing pending removals: %d track(s), %d source(s)...",
+        len(tracks),
+        len(remove_sources),
+    )
+    total = 0
+    with MusicLibrary(LIBRARY_DB) as lib:
+        for entry in tracks:
+            title = entry.get("title", "")
+            artist = entry.get("artist", "")
+            source = entry.get("source", "")
+            found = lib.clear_source_tag(title=title, artist=artist, source=source)
+            if not found:
+                logger.warning(
+                    "  WARNING: not found in beets — may need manual cleanup: %s by %s (source=%s)",
+                    title,
+                    artist,
+                    source,
+                )
+            total += 1
+
+        for source_name in remove_sources:
+            logger.info("==> Removing all tracks from playlist: %s", source_name)
+            items = lib.items_by_source(source_name)
+            for item in items:
+                item["source"] = ""
+                item.store()
+            m3u = PLAYLISTS / f"{source_name}.m3u"
+            m3u.unlink(missing_ok=True)
+            logger.info("  Cleared %d item(s) and removed .m3u for source=%s", len(items), source_name)
+            total += 1
+
+    return total
+
+
+_ASIS_REQUIRED_TAGS = ("title", "artist", "album", "tracknumber")
+
+
+def _move_asis_eligible(quarantine: Path, staging: Path) -> int:
+    """Move audio files from *quarantine* that have all required tags to *staging*.
+
+    Files missing title, artist, album, or tracknumber are left in quarantine.
+    Returns the count of files moved.
+    """
+    from mutagen import File as MutagenFile  # noqa: PLC0415 — beets dep, always available
+
+    moved = 0
+    for f in sorted(quarantine.rglob("*")):
+        if not f.is_file() or f.suffix.lower() not in AUDIO_EXTS:
+            continue
+        try:
+            tags = MutagenFile(f, easy=True)
+            if tags is None or not all(tags.get(k) for k in _ASIS_REQUIRED_TAGS):
+                continue
+        except Exception:
+            continue
+        dest = staging / f.relative_to(quarantine)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(f), dest)
+        moved += 1
+    return moved
+
+
+def _regen_playlists() -> None:
+    """Regenerate .m3u files for every .spotdl playlist."""
+    PLAYLISTS.mkdir(parents=True, exist_ok=True)
+    spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
+    if not spotdl_files:
+        logger.debug("No .spotdl files found — no playlists to generate")
+        return
+
+    with MusicLibrary(LIBRARY_DB) as lib:
+        for spotdl_file in spotdl_files:
+            name = spotdl_file.stem
+            m3u = PLAYLISTS / f"{name}.m3u"
+            logger.info("    Generating: %s", m3u)
+            paths = lib.paths_by_source(name)
+            lines = [os.path.relpath(p, PLAYLISTS) for p in sorted(paths)]
+            m3u.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def run() -> None:
+    """Execute the full scan pipeline, push metrics on completion."""
+    metrics = ScanMetrics()
+    start = time.monotonic()
+
+    try:
+        logger.info("==> music-scan starting")
+
+        logger.info("==> Processing pending removals from fetch container...")
+        metrics.tracks_removed = _process_pending_removals()
+
+        quarantined_before = _count_quarantine()
+
+        logger.info("==> Importing from inbox...")
+        skip_limit_env = os.environ.get("BEET_SKIP_LIMIT")
+        skip_limit = int(skip_limit_env) if skip_limit_env else None
+        if skip_limit is not None:
+            logger.info("Skip limit    : %d (early termination enabled)", skip_limit)
+        inbox_snapshot = _snapshot_inbox(INBOX)
+        logger.info("Inbox snapshot : %d audio file(s) queued for import", len(inbox_snapshot))
+        import_start = time.time()
+        run_beet_import(INBOX, skip_limit=skip_limit)
+
+        with MusicLibrary(LIBRARY_DB) as lib:
+            imported = lib.items_added_since(import_start)
+        logger.info("Newly imported : %d track(s)", len(imported))
+        _check_import_names(inbox_snapshot, imported)
+
+        logger.info("==> Quarantining skipped files...")
+        moved = _quarantine_inbox_leftovers()
+        logger.info("Quarantined : %d file(s) → %s", moved, QUARANTINE)
+        logger.info("Log         : ~/.config/beets/import.log")
+
+        logger.info("==> Importing quarantine with existing tags (--asis)...")
+        asis_start = time.time()
+        with tempfile.TemporaryDirectory(prefix="asis-staging-") as staging_str:
+            staging = Path(staging_str)
+            staged = _move_asis_eligible(QUARANTINE, staging)
+            logger.info("Asis eligible : %d file(s) with sufficient tags", staged)
+            if staged:
+                run_beet_import(staging, asis=True)
+                # Return any files beet skipped (e.g. duplicates) to quarantine
+                for remaining in staging.rglob("*"):
+                    if remaining.is_file() and remaining.suffix.lower() in AUDIO_EXTS:
+                        dest = QUARANTINE / remaining.relative_to(staging)
+                        dest.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.move(str(remaining), dest)
+        with MusicLibrary(LIBRARY_DB) as lib:
+            asis_imported = lib.items_added_since(asis_start)
+        logger.info("Asis pass     : %d track(s) imported from quarantine", len(asis_imported))
+        metrics.tracks_imported = len(imported) + len(asis_imported)
+
+        logger.info("==> Refreshing library metadata...")
+        run_beet_update()
+
+        logger.info("==> Regenerating playlists...")
+        _regen_playlists()
+
+        quarantined_after = _count_quarantine()
+        metrics.quarantined_tracks = max(0, quarantined_after - quarantined_before)
+
+        logger.info("==> music-scan complete")
+        if imported or asis_imported:
+            trigger_scan()
+
+    except Exception:
+        metrics.success = False
+        metrics.failure_reason = "unexpected_error"
+        logger.exception("music-scan failed")
+        raise
+    finally:
+        metrics.duration_seconds = int(time.monotonic() - start)
+        metrics.push()

--- a/scan/pyproject.toml
+++ b/scan/pyproject.toml
@@ -9,11 +9,11 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]
-music-scan = "pipeline.cli:main"
+music-scan = "music_scan.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["pipeline*"]
+include = ["music_scan*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scan/tests/test_metrics.py
+++ b/scan/tests/test_metrics.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pipeline.metrics import ScanMetrics, _gauge
+from music_scan.metrics import ScanMetrics, _gauge
 
 
 # ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ def test_gauge_float_value() -> None:
 
 def test_scan_metrics_success_body(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_scan.metrics._push", lambda body, job: pushed.append(body))
 
     m = ScanMetrics(success=True, duration_seconds=30, quarantined_tracks=2)
     m.push()
@@ -46,7 +46,7 @@ def test_scan_metrics_success_body(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_scan_metrics_failure_includes_reason(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_scan.metrics._push", lambda body, job: pushed.append(body))
 
     m = ScanMetrics(success=False, failure_reason="disk_full")
     m.push()
@@ -58,14 +58,14 @@ def test_scan_metrics_failure_includes_reason(monkeypatch: pytest.MonkeyPatch) -
 
 def test_push_job_label_scan(monkeypatch: pytest.MonkeyPatch) -> None:
     jobs: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: jobs.append(job))
+    monkeypatch.setattr("music_scan.metrics._push", lambda body, job: jobs.append(job))
     ScanMetrics().push()
     assert jobs == ["music_scan"]
 
 
 def test_scan_metrics_tracks_imported(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_scan.metrics._push", lambda body, job: pushed.append(body))
 
     m = ScanMetrics(tracks_imported=15, tracks_removed=3)
     m.push()
@@ -77,7 +77,7 @@ def test_scan_metrics_tracks_imported(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_scan_metrics_track_counters_default_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
-    monkeypatch.setattr("pipeline.metrics._push", lambda body, job: pushed.append(body))
+    monkeypatch.setattr("music_scan.metrics._push", lambda body, job: pushed.append(body))
 
     ScanMetrics().push()
 

--- a/scan/tests/test_music_pipeline.py
+++ b/scan/tests/test_music_pipeline.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from beets import importer as beets_importer
 
-from pipeline.music_pipeline import (
+from music_scan.music_pipeline import (
     MusicPipelinePlugin,
     _all_via_spotdl,
     _playlist_from_path,
@@ -338,7 +338,7 @@ def test_handle_duplicates_manual_duplicate_sets_skip() -> None:
     task = _task(item=item)
     task.find_duplicates.return_value = [_dup(via="")]  # no via = manual
 
-    with patch("pipeline.music_pipeline.Path"):
+    with patch("music_scan.music_pipeline.Path"):
         plugin.handle_duplicates(session=MagicMock(), task=task)
 
     task.set_choice.assert_called_once_with(beets_importer.Action.SKIP)
@@ -350,7 +350,7 @@ def test_handle_duplicates_manual_duplicate_deletes_inbox_file() -> None:
     task = _task(item=item)
     task.find_duplicates.return_value = [_dup(via="")]
 
-    with patch("pipeline.music_pipeline.Path") as mock_path:
+    with patch("music_scan.music_pipeline.Path") as mock_path:
         plugin.handle_duplicates(session=MagicMock(), task=task)
 
     mock_path.return_value.unlink.assert_called_once_with(missing_ok=True)

--- a/scan/tests/test_navidrome.py
+++ b/scan/tests/test_navidrome.py
@@ -22,8 +22,8 @@ def clear_navidrome_env(monkeypatch):
 
 def test_no_url_skips_http_call():
     """When NAVIDROME_URL is unset, no HTTP request is made."""
-    with mock.patch("pipeline.navidrome.requests.get") as mock_get:
-        from pipeline.navidrome import trigger_scan
+    with mock.patch("music_scan.navidrome.requests.get") as mock_get:
+        from music_scan.navidrome import trigger_scan
         trigger_scan()
     mock_get.assert_not_called()
 
@@ -32,10 +32,10 @@ def test_url_without_credentials_logs_warning(monkeypatch, caplog):
     """When URL is set but credentials are missing, log a warning and skip."""
     monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
 
-    with mock.patch("pipeline.navidrome.requests.get") as mock_get:
+    with mock.patch("music_scan.navidrome.requests.get") as mock_get:
         import logging
-        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
-            from pipeline.navidrome import trigger_scan
+        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
+            from music_scan.navidrome import trigger_scan
             trigger_scan()
 
     mock_get.assert_not_called()
@@ -47,10 +47,10 @@ def test_url_with_only_user_logs_warning(monkeypatch, caplog):
     monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
     monkeypatch.setenv("NAVIDROME_USER", "admin")
 
-    with mock.patch("pipeline.navidrome.requests.get") as mock_get:
+    with mock.patch("music_scan.navidrome.requests.get") as mock_get:
         import logging
-        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
-            from pipeline.navidrome import trigger_scan
+        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
+            from music_scan.navidrome import trigger_scan
             trigger_scan()
 
     mock_get.assert_not_called()
@@ -66,10 +66,10 @@ def test_successful_scan_logs_info(monkeypatch, caplog):
     mock_resp = mock.Mock()
     mock_resp.json.return_value = _make_subsonic_response("ok")
 
-    with mock.patch("pipeline.navidrome.requests.get", return_value=mock_resp) as mock_get:
+    with mock.patch("music_scan.navidrome.requests.get", return_value=mock_resp) as mock_get:
         import logging
-        with caplog.at_level(logging.INFO, logger="pipeline.navidrome"):
-            from pipeline.navidrome import trigger_scan
+        with caplog.at_level(logging.INFO, logger="music_scan.navidrome"):
+            from music_scan.navidrome import trigger_scan
             trigger_scan()
 
     mock_get.assert_called_once()
@@ -89,8 +89,8 @@ def test_trailing_slash_in_url_is_normalized(monkeypatch):
     mock_resp = mock.Mock()
     mock_resp.json.return_value = _make_subsonic_response("ok")
 
-    with mock.patch("pipeline.navidrome.requests.get", return_value=mock_resp) as mock_get:
-        from pipeline.navidrome import trigger_scan
+    with mock.patch("music_scan.navidrome.requests.get", return_value=mock_resp) as mock_get:
+        from music_scan.navidrome import trigger_scan
         trigger_scan()
 
     url_called = mock_get.call_args[0][0]
@@ -106,10 +106,10 @@ def test_non_ok_subsonic_status_logs_warning(monkeypatch, caplog):
     mock_resp = mock.Mock()
     mock_resp.json.return_value = _make_subsonic_response("failed")
 
-    with mock.patch("pipeline.navidrome.requests.get", return_value=mock_resp):
+    with mock.patch("music_scan.navidrome.requests.get", return_value=mock_resp):
         import logging
-        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
-            from pipeline.navidrome import trigger_scan
+        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
+            from music_scan.navidrome import trigger_scan
             trigger_scan()
 
     assert "non-ok status" in caplog.text
@@ -122,12 +122,12 @@ def test_http_error_logs_warning(monkeypatch, caplog):
     monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
 
     with mock.patch(
-        "pipeline.navidrome.requests.get",
+        "music_scan.navidrome.requests.get",
         side_effect=requests.ConnectionError("connection refused"),
     ):
         import logging
-        with caplog.at_level(logging.WARNING, logger="pipeline.navidrome"):
-            from pipeline.navidrome import trigger_scan
+        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
+            from music_scan.navidrome import trigger_scan
             trigger_scan()
 
     assert "Failed to trigger Navidrome rescan" in caplog.text

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -30,13 +30,13 @@ def test_relative_path_same_dir_file() -> None:
 
 
 def test_count_quarantine_empty(tmp_path: Path) -> None:
-    from pipeline.scan import _count_quarantine, QUARANTINE
+    from music_scan.scan import _count_quarantine, QUARANTINE
     import unittest.mock as mock
 
     fake_quarantine = tmp_path / "quarantine"
     fake_quarantine.mkdir()
 
-    with mock.patch("pipeline.scan.QUARANTINE", fake_quarantine):
+    with mock.patch("music_scan.scan.QUARANTINE", fake_quarantine):
         from pipeline import scan
         count = scan._count_quarantine()
     assert count == 0
@@ -50,14 +50,14 @@ def test_count_quarantine_with_files(tmp_path: Path) -> None:
     (fake_quarantine / "a.mp3").touch()
     (fake_quarantine / "b.m4a").touch()
 
-    with mock.patch("pipeline.scan.QUARANTINE", fake_quarantine):
+    with mock.patch("music_scan.scan.QUARANTINE", fake_quarantine):
         from pipeline import scan
         count = scan._count_quarantine()
     assert count == 2
 
 
 def test_quarantine_leftovers(tmp_path: Path) -> None:
-    from pipeline.scan import _quarantine_inbox_leftovers
+    from music_scan.scan import _quarantine_inbox_leftovers
 
     inbox = tmp_path / "inbox"
     inbox.mkdir()
@@ -72,7 +72,7 @@ def test_quarantine_leftovers(tmp_path: Path) -> None:
     # Non-audio file — must not be touched
     (inbox / "readme.txt").touch()
 
-    with mock.patch("pipeline.scan.INBOX", inbox), mock.patch("pipeline.scan.QUARANTINE", quarantine):
+    with mock.patch("music_scan.scan.INBOX", inbox), mock.patch("music_scan.scan.QUARANTINE", quarantine):
         moved = _quarantine_inbox_leftovers()
 
     assert moved == 2
@@ -87,16 +87,16 @@ def test_quarantine_leftovers(tmp_path: Path) -> None:
 
 
 def test_process_pending_removals_no_file(tmp_path: Path) -> None:
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path):
         count = _process_pending_removals()
     assert count == 0
 
 
 def test_process_pending_removals_reads_and_deletes(tmp_path: Path) -> None:
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     data = {"tracks": [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}], "remove_sources": []}
@@ -107,8 +107,8 @@ def test_process_pending_removals_reads_and_deletes(tmp_path: Path) -> None:
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         count = _process_pending_removals()
 
     assert count == 1
@@ -119,12 +119,12 @@ def test_process_pending_removals_reads_and_deletes(tmp_path: Path) -> None:
 
 
 def test_process_pending_removals_empty_data(tmp_path: Path) -> None:
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     fake_path.write_text(json.dumps({"tracks": [], "remove_sources": []}), encoding="utf-8")
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path):
         count = _process_pending_removals()
 
     assert count == 0
@@ -133,12 +133,12 @@ def test_process_pending_removals_empty_data(tmp_path: Path) -> None:
 
 def test_process_pending_removals_malformed_json_deletes_file(tmp_path: Path) -> None:
     """Malformed JSON must not leave the file in place (would break every future scan run)."""
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     fake_path.write_text("not valid json {{{{", encoding="utf-8")
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path):
         count = _process_pending_removals()
 
     assert count == 0
@@ -146,7 +146,7 @@ def test_process_pending_removals_malformed_json_deletes_file(tmp_path: Path) ->
 
 
 def test_process_pending_removals_multi_track(tmp_path: Path) -> None:
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     data = {
@@ -163,8 +163,8 @@ def test_process_pending_removals_multi_track(tmp_path: Path) -> None:
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         count = _process_pending_removals()
 
     assert count == 2
@@ -174,7 +174,7 @@ def test_process_pending_removals_multi_track(tmp_path: Path) -> None:
 
 def test_process_pending_removals_remove_sources(tmp_path: Path) -> None:
     """remove_sources → items_by_source called, source tags cleared, .m3u deleted."""
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     playlists_dir = tmp_path / "playlists"
@@ -191,9 +191,9 @@ def test_process_pending_removals_remove_sources(tmp_path: Path) -> None:
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.items_by_source = mock.MagicMock(return_value=[mock_item])
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("pipeline.scan.PLAYLISTS", playlists_dir), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         count = _process_pending_removals()
 
     assert count == 1
@@ -206,7 +206,7 @@ def test_process_pending_removals_remove_sources(tmp_path: Path) -> None:
 
 def test_process_pending_removals_remove_source_missing_m3u(tmp_path: Path) -> None:
     """remove_sources processing doesn't fail if .m3u doesn't exist."""
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     playlists_dir = tmp_path / "playlists"
@@ -220,9 +220,9 @@ def test_process_pending_removals_remove_source_missing_m3u(tmp_path: Path) -> N
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.items_by_source = mock.MagicMock(return_value=[])
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("pipeline.scan.PLAYLISTS", playlists_dir), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         count = _process_pending_removals()
 
     assert count == 1
@@ -230,7 +230,7 @@ def test_process_pending_removals_remove_source_missing_m3u(tmp_path: Path) -> N
 
 def test_process_pending_removals_backward_compat_old_list_format(tmp_path: Path) -> None:
     """Old list format is still processed correctly."""
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     old_format = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
@@ -241,8 +241,8 @@ def test_process_pending_removals_backward_compat_old_list_format(tmp_path: Path
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         count = _process_pending_removals()
 
     assert count == 1
@@ -257,7 +257,7 @@ def test_process_pending_removals_backward_compat_old_list_format(tmp_path: Path
 
 
 def test_regen_playlists_writes_m3u_with_relative_paths(tmp_path: Path) -> None:
-    from pipeline.scan import _regen_playlists
+    from music_scan.scan import _regen_playlists
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -273,10 +273,10 @@ def test_regen_playlists_writes_m3u_with_relative_paths(tmp_path: Path) -> None:
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.paths_by_source = mock.MagicMock(return_value=[track_path])
 
-    with mock.patch("pipeline.scan.SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.scan.PLAYLISTS", playlists_dir), \
-         mock.patch("pipeline.scan.LIBRARY_DB", tmp_path / "library.db"), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.SPOTDL_DIR", spotdl_dir), \
+         mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
+         mock.patch("music_scan.scan.LIBRARY_DB", tmp_path / "library.db"), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         _regen_playlists()
 
     m3u = playlists_dir / "my-playlist.m3u"
@@ -288,7 +288,7 @@ def test_regen_playlists_writes_m3u_with_relative_paths(tmp_path: Path) -> None:
 
 
 def test_regen_playlists_empty_playlist_writes_empty_m3u(tmp_path: Path) -> None:
-    from pipeline.scan import _regen_playlists
+    from music_scan.scan import _regen_playlists
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -302,10 +302,10 @@ def test_regen_playlists_empty_playlist_writes_empty_m3u(tmp_path: Path) -> None
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.paths_by_source = mock.MagicMock(return_value=[])
 
-    with mock.patch("pipeline.scan.SPOTDL_DIR", spotdl_dir), \
-         mock.patch("pipeline.scan.PLAYLISTS", playlists_dir), \
-         mock.patch("pipeline.scan.LIBRARY_DB", tmp_path / "library.db"), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.SPOTDL_DIR", spotdl_dir), \
+         mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
+         mock.patch("music_scan.scan.LIBRARY_DB", tmp_path / "library.db"), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         _regen_playlists()
 
     m3u = playlists_dir / "empty-playlist.m3u"
@@ -319,7 +319,7 @@ def test_regen_playlists_empty_playlist_writes_empty_m3u(tmp_path: Path) -> None
 
 
 def test_snapshot_inbox_finds_audio_files(tmp_path: Path) -> None:
-    from pipeline.scan import _snapshot_inbox
+    from music_scan.scan import _snapshot_inbox
 
     inbox = tmp_path / "inbox"
     inbox.mkdir()
@@ -328,14 +328,14 @@ def test_snapshot_inbox_finds_audio_files(tmp_path: Path) -> None:
     (inbox / "sub" / "Four Tet - Pyramid.flac").touch()
     (inbox / "readme.txt").touch()
 
-    with mock.patch("pipeline.scan.AUDIO_EXTS", {".m4a", ".flac"}):
+    with mock.patch("music_scan.scan.AUDIO_EXTS", {".m4a", ".flac"}):
         stems = _snapshot_inbox(inbox)
 
     assert stems == ["DJ Koze - Pick Up", "Four Tet - Pyramid"]
 
 
 def test_name_words_normalises_correctly() -> None:
-    from pipeline.scan import _name_words
+    from music_scan.scan import _name_words
 
     assert _name_words("DJ Koze - Pick Up") == {"koze", "pick"}
     assert _name_words("Four Tet - Pyramid") == {"four", "tet", "pyramid"}
@@ -345,13 +345,13 @@ def test_name_words_normalises_correctly() -> None:
 
 
 def test_check_import_names_no_flags_on_good_match(caplog: pytest.LogCaptureFixture) -> None:
-    from pipeline.scan import _check_import_names
+    from music_scan.scan import _check_import_names
     import logging
 
     inbox = ["DJ Koze - Pick Up", "Four Tet - Pyramid"]
     imported = [("Pick Up", "DJ Koze"), ("Pyramid", "Four Tet")]
 
-    with caplog.at_level(logging.INFO, logger="pipeline.scan"):
+    with caplog.at_level(logging.INFO, logger="music_scan.scan"):
         _check_import_names(inbox, imported)
 
     assert "Name check OK" in caplog.text
@@ -359,13 +359,13 @@ def test_check_import_names_no_flags_on_good_match(caplog: pytest.LogCaptureFixt
 
 
 def test_check_import_names_flags_bad_match(caplog: pytest.LogCaptureFixture) -> None:
-    from pipeline.scan import _check_import_names
+    from music_scan.scan import _check_import_names
     import logging
 
     inbox = ["DJ Koze - Pick Up"]
     imported = [("Never Be Like You", "Flume")]  # completely different
 
-    with caplog.at_level(logging.WARNING, logger="pipeline.scan"):
+    with caplog.at_level(logging.WARNING, logger="music_scan.scan"):
         _check_import_names(inbox, imported)
 
     assert "!!" in caplog.text
@@ -380,7 +380,7 @@ def _fake_tags(overrides: dict | None = None) -> dict:
 
 
 def test_move_asis_eligible_moves_fully_tagged_file(tmp_path: Path) -> None:
-    from pipeline.scan import _move_asis_eligible
+    from music_scan.scan import _move_asis_eligible
 
     quarantine = tmp_path / "quarantine"
     quarantine.mkdir()
@@ -397,7 +397,7 @@ def test_move_asis_eligible_moves_fully_tagged_file(tmp_path: Path) -> None:
 
 
 def test_move_asis_eligible_leaves_untagged_file(tmp_path: Path) -> None:
-    from pipeline.scan import _move_asis_eligible
+    from music_scan.scan import _move_asis_eligible
 
     quarantine = tmp_path / "quarantine"
     quarantine.mkdir()
@@ -414,7 +414,7 @@ def test_move_asis_eligible_leaves_untagged_file(tmp_path: Path) -> None:
 
 
 def test_move_asis_eligible_leaves_partially_tagged_file(tmp_path: Path) -> None:
-    from pipeline.scan import _move_asis_eligible
+    from music_scan.scan import _move_asis_eligible
 
     quarantine = tmp_path / "quarantine"
     quarantine.mkdir()
@@ -431,13 +431,13 @@ def test_move_asis_eligible_leaves_partially_tagged_file(tmp_path: Path) -> None
 
 
 def test_run_beet_import_asis_flag() -> None:
-    from pipeline.process import run_beet_import
+    from music_scan.process import run_beet_import
     import unittest.mock as mock
 
     mock_proc = mock.MagicMock()
     mock_proc.wait.return_value = 0
     with mock.patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
-         mock.patch("pipeline.process.IMPORT_LOG") as mock_log:
+         mock.patch("music_scan.process.IMPORT_LOG") as mock_log:
         mock_log.exists.return_value = False
         run_beet_import(Path("/some/dir"), asis=True)
 
@@ -447,13 +447,13 @@ def test_run_beet_import_asis_flag() -> None:
 
 
 def test_run_beet_import_no_asis_flag_by_default() -> None:
-    from pipeline.process import run_beet_import
+    from music_scan.process import run_beet_import
     import unittest.mock as mock
 
     mock_proc = mock.MagicMock()
     mock_proc.wait.return_value = 0
     with mock.patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
-         mock.patch("pipeline.process.IMPORT_LOG") as mock_log:
+         mock.patch("music_scan.process.IMPORT_LOG") as mock_log:
         mock_log.exists.return_value = False
         run_beet_import(Path("/some/dir"))
 
@@ -464,7 +464,7 @@ def test_run_beet_import_no_asis_flag_by_default() -> None:
 
 def test_process_pending_removals_file_deleted_before_processing(tmp_path: Path) -> None:
     """File is unlinked before processing so an exception mid-processing doesn't re-block scans."""
-    from pipeline.scan import _process_pending_removals
+    from music_scan.scan import _process_pending_removals
 
     fake_path = tmp_path / ".pending-removals.json"
     data = {"tracks": [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}], "remove_sources": []}
@@ -475,8 +475,8 @@ def test_process_pending_removals_file_deleted_before_processing(tmp_path: Path)
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.clear_source_tag = mock.MagicMock(side_effect=RuntimeError("beets exploded"))
 
-    with mock.patch("pipeline.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("pipeline.scan.MusicLibrary", return_value=mock_lib):
+    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
         with pytest.raises(RuntimeError):
             _process_pending_removals()
 

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -37,7 +37,7 @@ def test_count_quarantine_empty(tmp_path: Path) -> None:
     fake_quarantine.mkdir()
 
     with mock.patch("music_scan.scan.QUARANTINE", fake_quarantine):
-        from pipeline import scan
+        from music_scan import scan
         count = scan._count_quarantine()
     assert count == 0
 
@@ -51,7 +51,7 @@ def test_count_quarantine_with_files(tmp_path: Path) -> None:
     (fake_quarantine / "b.m4a").touch()
 
     with mock.patch("music_scan.scan.QUARANTINE", fake_quarantine):
-        from pipeline import scan
+        from music_scan import scan
         count = scan._count_quarantine()
     assert count == 2
 


### PR DESCRIPTION
## Summary

- `fetch/pipeline/` → `fetch/music_fetch/` (package `music_fetch`)
- `scan/pipeline/` → `scan/music_scan/` (package `music_scan`)
- Updates all internal imports, `mock.patch` targets, `pyproject.toml` entry points, Dockerfiles, and beets `pluginpath`

No functional changes — pure rename to eliminate the package name collision that would occur in the unified service image.

Closes #63

## Test plan

- [ ] `just test` — both fetch and scan test suites pass
- [ ] `music-ingest` and `music-scan` entry points still resolve correctly
- [ ] Each package installs independently with no name collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)