### PR TITLE
refactor: replace pending-removals.json with PendingRemovals dataclass

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: Install dependencies
         working-directory: scan
-        run: pip install -r requirements.txt -r requirements-dev.txt -e .
+        run: |
+          pip install -e ../fetch
+          pip install -r requirements.txt -r requirements-dev.txt -e .
 
       - name: Run tests
         working-directory: scan
@@ -64,7 +66,8 @@ jobs:
       - name: Build scan image
         uses: docker/build-push-action@v7
         with:
-          context: scan
+          context: .
+          file: scan/Dockerfile
           target: prod
           push: false
           load: true
@@ -101,7 +104,8 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v7
         with:
-          context: scan
+          context: .
+          file: scan/Dockerfile
           target: prod
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/compose.yml
+++ b/compose.yml
@@ -27,7 +27,8 @@ services:
 
   scan:
     build:
-      context: scan
+      context: .
+      dockerfile: scan/Dockerfile
       target: prod
     image: ghcr.io/sometimeskind/music-pipeline-scan:latest
     volumes:

--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -1,4 +1,4 @@
-"""music-ingest: reconcile playlists.conf → daily spotdl sync loop → write pending-removals.
+"""music-ingest: reconcile playlists.conf → daily spotdl sync loop → return pending removals.
 
 On each run:
 1. Reconcile disk state with playlists.conf:
@@ -9,12 +9,13 @@ On each run:
 2. For each remaining .spotdl playlist:
    a. Diff old vs new Spotify URL sets to find removed tracks.
    b. Download new tracks (overwrite=skip ignores already-downloaded files).
-   c. Write removed track info to .pending-removals.json on the shared volume.
-   music-scan reads this file to clear beets source tags (soft delete — files stay in library).
+3. Return a PendingRemovals dataclass for the caller (e.g. the service orchestrator) to
+   pass to music-scan for beets source-tag cleanup (soft delete — files stay in library).
 """
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
@@ -31,8 +32,13 @@ logger = logging.getLogger(__name__)
 
 SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
 COOKIE_FILE = Path("/root/.config/spotdl/cookies.txt")
-PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
 CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
+
+
+@dataclasses.dataclass
+class PendingRemovals:
+    tracks: list[dict]
+    remove_sources: list[str]
 
 
 def _deadline_reached(elapsed: float, timeout: int | None) -> bool:
@@ -167,60 +173,8 @@ def _collect_removals(
         pending.append({"title": title, "artist": artist, "source": playlist_name})
 
 
-def _write_pending_removals(pending: list[dict], remove_sources: list[str] | None = None) -> None:
-    """Write pending source-tag removals to the shared volume for music-scan.
-
-    Writes {"tracks": [...], "remove_sources": [...]} format.
-    Merges with any existing file so multiple fetch runs before a scan don't
-    overwrite each other.  Supports merging with old list-format files.
-    """
-    remove_sources = remove_sources or []
-    if not pending and not remove_sources:
-        return
-
-    PENDING_REMOVALS.parent.mkdir(parents=True, exist_ok=True)
-
-    # Load and merge — safe if fetch runs multiple times before scan processes the file.
-    existing_tracks: list[dict] = []
-    existing_remove_sources: list[str] = []
-    if PENDING_REMOVALS.exists():
-        try:
-            with open(PENDING_REMOVALS, encoding="utf-8") as fh:
-                existing = json.load(fh)
-            if isinstance(existing, list):
-                # Old format: just a list of track entries.
-                existing_tracks = existing
-            else:
-                existing_tracks = existing.get("tracks", [])
-                existing_remove_sources = existing.get("remove_sources", [])
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.error("Could not read %s — discarding prior pending removals: %s", PENDING_REMOVALS, exc)
-
-    merged_tracks = existing_tracks + pending
-    merged_remove_sources = existing_remove_sources + remove_sources
-
-    # Atomic write: write to a temp file then rename so a mid-write failure never
-    # truncates the existing file.
-    tmp = PENDING_REMOVALS.with_suffix(".tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump(
-            {"tracks": merged_tracks, "remove_sources": merged_remove_sources},
-            fh,
-            indent=2,
-            ensure_ascii=False,
-        )
-    tmp.replace(PENDING_REMOVALS)
-
-    logger.info(
-        "==> Wrote %d pending track removal(s) and %d source removal(s) to %s",
-        len(pending),
-        len(remove_sources),
-        PENDING_REMOVALS,
-    )
-
-
-def run() -> None:
-    """Execute the full ingest pipeline, push metrics on completion."""
+def run() -> PendingRemovals:
+    """Execute the full ingest pipeline, push metrics on completion, return pending removals."""
     metrics = IngestMetrics()
     start = time.monotonic()
 
@@ -346,9 +300,8 @@ def run() -> None:
             # Brief pause between playlists — avoid hammering Spotify/YouTube APIs.
             time.sleep(5)
 
-        _write_pending_removals(pending_removals, remove_sources)
-
         logger.info("==> music-ingest complete. Run music-scan for local import and playlist generation.")
+        return PendingRemovals(tracks=pending_removals, remove_sources=remove_sources)
 
     except SystemExit:
         raise

--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -36,8 +36,15 @@ CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
 
 
 @dataclasses.dataclass
+class RemovedTrack:
+    title: str
+    artist: str
+    source: str
+
+
+@dataclasses.dataclass
 class PendingRemovals:
-    tracks: list[dict]
+    tracks: list[RemovedTrack]
     remove_sources: list[str]
 
 
@@ -146,7 +153,7 @@ def _reconcile_playlists() -> list[str]:
 
 
 def _collect_removals(
-    pending: list[dict],
+    pending: list[RemovedTrack],
     removed_urls: set[str],
     old_songs: list[dict],
     playlist_name: str,
@@ -170,7 +177,7 @@ def _collect_removals(
         artists = entry.get("artists", [])
         artist = artists[0] if artists else ""
         logger.info("  Scheduling unlink: %s — %s", title, artist)
-        pending.append({"title": title, "artist": artist, "source": playlist_name})
+        pending.append(RemovedTrack(title=title, artist=artist, source=playlist_name))
 
 
 def run() -> PendingRemovals:
@@ -226,7 +233,7 @@ def run() -> PendingRemovals:
         if not spotdl_files:
             logger.info("No .spotdl files found in %s", SPOTDL_DIR)
 
-        pending_removals: list[dict] = []
+        pending_removals: list[RemovedTrack] = []
 
         for spotdl_file in spotdl_files:
             name = spotdl_file.stem

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, _write_pending_removals
+from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, PendingRemovals
 from music_fetch.spotdl_ops import find_track_in_snapshot
 
 
@@ -238,131 +238,56 @@ def test_collect_removals_no_removed_urls() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _write_pending_removals — new {tracks, remove_sources} format
+# run() — PendingRemovals return type
 # ---------------------------------------------------------------------------
 
 
-def test_write_pending_removals_creates_file(tmp_path: Path) -> None:
+def test_run_returns_pending_removals_empty(tmp_path: Path) -> None:
+    """run() returns PendingRemovals(tracks=[], remove_sources=[]) when nothing to remove."""
     import unittest.mock as mock
     from music_fetch import ingest
 
-    fake_path = tmp_path / ".pending-removals.json"
-    entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+    spotdl_dir = tmp_path / "spotdl"
+    spotdl_dir.mkdir()
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.touch()
 
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals(entries)
+    with mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
+         mock.patch.object(ingest, "COOKIE_FILE", cookie_file), \
+         mock.patch.object(ingest, "CONF_PATH", tmp_path / "missing.conf"), \
+         mock.patch.dict("os.environ", {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}), \
+         mock.patch("shutil.disk_usage", return_value=mock.Mock(free=10 * 1024**3)), \
+         mock.patch("music_fetch.ingest.IngestMetrics"), \
+         mock.patch("music_fetch.ingest._jitter"):
+        result = ingest.run()
 
-    assert fake_path.exists()
-    result = json.loads(fake_path.read_text())
-    assert result == {"tracks": entries, "remove_sources": []}
+    assert isinstance(result, PendingRemovals)
+    assert result.tracks == []
+    assert result.remove_sources == []
 
 
-def test_write_pending_removals_with_remove_sources(tmp_path: Path) -> None:
+def test_run_returns_pending_removals_with_remove_sources(tmp_path: Path) -> None:
+    """run() returns PendingRemovals with remove_sources from _reconcile_playlists."""
     import unittest.mock as mock
     from music_fetch import ingest
 
-    fake_path = tmp_path / ".pending-removals.json"
-    tracks = [{"title": "Song A", "artist": "Artist 1", "source": "pl-1"}]
-    sources = ["old-playlist"]
+    spotdl_dir = tmp_path / "spotdl"
+    spotdl_dir.mkdir()
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.touch()
 
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals(tracks, sources)
+    with mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
+         mock.patch.object(ingest, "COOKIE_FILE", cookie_file), \
+         mock.patch.dict("os.environ", {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}), \
+         mock.patch("shutil.disk_usage", return_value=mock.Mock(free=10 * 1024**3)), \
+         mock.patch("music_fetch.ingest._reconcile_playlists", return_value=["gone-playlist"]), \
+         mock.patch("music_fetch.ingest.IngestMetrics"), \
+         mock.patch("music_fetch.ingest._jitter"):
+        result = ingest.run()
 
-    result = json.loads(fake_path.read_text())
-    assert result == {"tracks": tracks, "remove_sources": sources}
-
-
-def test_write_pending_removals_appends_to_existing(tmp_path: Path) -> None:
-    """The append-safe merge is the key correctness guarantee of the cross-container handoff."""
-    import unittest.mock as mock
-    from music_fetch import ingest
-
-    fake_path = tmp_path / ".pending-removals.json"
-    existing = {"tracks": [{"title": "Song A", "artist": "Artist 1", "source": "playlist-1"}], "remove_sources": []}
-    fake_path.write_text(json.dumps(existing), encoding="utf-8")
-
-    new_entries = [{"title": "Song B", "artist": "Artist 2", "source": "playlist-2"}]
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals(new_entries)
-
-    result = json.loads(fake_path.read_text())
-    assert result["tracks"] == existing["tracks"] + new_entries
-    assert result["remove_sources"] == []
-
-
-def test_write_pending_removals_merges_remove_sources(tmp_path: Path) -> None:
-    """remove_sources from multiple fetch runs are accumulated."""
-    import unittest.mock as mock
-    from music_fetch import ingest
-
-    fake_path = tmp_path / ".pending-removals.json"
-    existing = {"tracks": [], "remove_sources": ["old-playlist"]}
-    fake_path.write_text(json.dumps(existing), encoding="utf-8")
-
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals([], ["another-removed"])
-
-    result = json.loads(fake_path.read_text())
-    assert result["remove_sources"] == ["old-playlist", "another-removed"]
-
-
-def test_write_pending_removals_merges_with_old_format_file(tmp_path: Path) -> None:
-    """Old list-format file is read and merged into the new dict format."""
-    import unittest.mock as mock
-    from music_fetch import ingest
-
-    fake_path = tmp_path / ".pending-removals.json"
-    old_format = [{"title": "Song A", "artist": "Artist 1", "source": "playlist-1"}]
-    fake_path.write_text(json.dumps(old_format), encoding="utf-8")
-
-    new_entries = [{"title": "Song B", "artist": "Artist 2", "source": "playlist-2"}]
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals(new_entries)
-
-    result = json.loads(fake_path.read_text())
-    assert result["tracks"] == old_format + new_entries
-    assert result["remove_sources"] == []
-
-
-def test_write_pending_removals_recovers_from_corrupt_file(tmp_path: Path) -> None:
-    """Corrupt existing file is discarded; new entries are still written."""
-    import unittest.mock as mock
-    from music_fetch import ingest
-
-    fake_path = tmp_path / ".pending-removals.json"
-    fake_path.write_text("not valid json", encoding="utf-8")
-
-    entries = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals(entries)
-
-    result = json.loads(fake_path.read_text())
-    assert result["tracks"] == entries
-    assert result["remove_sources"] == []
-
-
-def test_write_pending_removals_noop_when_empty(tmp_path: Path) -> None:
-    """No file created when there are no pending removals."""
-    import unittest.mock as mock
-    from music_fetch import ingest
-
-    fake_path = tmp_path / ".pending-removals.json"
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals([])
-
-    assert not fake_path.exists()
-
-
-def test_write_pending_removals_noop_with_only_empty_remove_sources(tmp_path: Path) -> None:
-    """No file created when remove_sources is an empty list."""
-    import unittest.mock as mock
-    from music_fetch import ingest
-
-    fake_path = tmp_path / ".pending-removals.json"
-    with mock.patch.object(ingest, "PENDING_REMOVALS", fake_path):
-        _write_pending_removals([], [])
-
-    assert not fake_path.exists()
+    assert isinstance(result, PendingRemovals)
+    assert result.remove_sources == ["gone-playlist"]
+    assert result.tracks == []
 
 
 # ---------------------------------------------------------------------------

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, PendingRemovals
+from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, PendingRemovals, RemovedTrack
 from music_fetch.spotdl_ops import find_track_in_snapshot
 
 
@@ -212,27 +212,27 @@ SNAPSHOT = [
 
 
 def test_collect_removals_normal_case() -> None:
-    pending: list[dict] = []
+    pending: list[RemovedTrack] = []
     _collect_removals(pending, {"https://spotify.com/track/A"}, SNAPSHOT, "my-playlist")
-    assert pending == [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
+    assert pending == [RemovedTrack(title="Song A", artist="Artist 1", source="my-playlist")]
 
 
 def test_collect_removals_url_not_in_snapshot() -> None:
     """URL missing from snapshot → entry is skipped, no crash."""
-    pending: list[dict] = []
+    pending: list[RemovedTrack] = []
     _collect_removals(pending, {"https://spotify.com/track/Z"}, SNAPSHOT, "my-playlist")
     assert pending == []
 
 
 def test_collect_removals_empty_artists() -> None:
     """artists=[] → artist field defaults to empty string."""
-    pending: list[dict] = []
+    pending: list[RemovedTrack] = []
     _collect_removals(pending, {"https://spotify.com/track/B"}, SNAPSHOT, "my-playlist")
-    assert pending == [{"title": "Song B", "artist": "", "source": "my-playlist"}]
+    assert pending == [RemovedTrack(title="Song B", artist="", source="my-playlist")]
 
 
 def test_collect_removals_no_removed_urls() -> None:
-    pending: list[dict] = []
+    pending: list[RemovedTrack] = []
     _collect_removals(pending, set(), SNAPSHOT, "my-playlist")
     assert pending == []
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 test:
     docker build --target dev -t music-pipeline-fetch:dev fetch
     docker run --rm music-pipeline-fetch:dev
-    docker build --target dev -t music-pipeline-scan:dev scan
+    docker build --target dev -f scan/Dockerfile -t music-pipeline-scan:dev .
     docker run --rm music-pipeline-scan:dev
 
 # Run container integration tests against the current GHCR image (no auth needed)

--- a/scan/Dockerfile
+++ b/scan/Dockerfile
@@ -1,5 +1,6 @@
 # scan: beets import, AcoustID fingerprinting, .m3u generation.
 # No Spotify or YouTube calls — reads inbox written by the fetch container.
+# Build context: repo root (required to install the shared music_fetch package).
 FROM python:3.13-slim AS prod
 
 # System dependencies: ffmpeg for audio processing, chromaprint for AcoustID fingerprinting.
@@ -8,13 +9,18 @@ RUN apt-get update && apt-get install -y \
     libchromaprint-tools \
     && rm -rf /var/lib/apt/lists/*
 
+# Install the fetch package first — music_scan imports PendingRemovals from it.
+COPY fetch/music_fetch/ /app/fetch/music_fetch/
+COPY fetch/pyproject.toml /app/fetch/pyproject.toml
+RUN pip install --no-cache-dir -e /app/fetch
+
 # Python dependencies
-COPY requirements.txt /requirements.txt
+COPY scan/requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt
 
-# Install the pipeline package — entry points land in /usr/local/bin/
-COPY music_scan/ /app/music_scan/
-COPY pyproject.toml /app/pyproject.toml
+# Install the scan pipeline package — entry points land in /usr/local/bin/
+COPY scan/music_scan/ /app/music_scan/
+COPY scan/pyproject.toml /app/pyproject.toml
 RUN pip install --no-cache-dir -e /app
 
 # Pre-create directories that will be populated by volume mounts
@@ -30,9 +36,9 @@ CMD ["music-scan"]
 
 # dev stage: extends prod with test deps; used by `just test`, never pushed to registry
 FROM prod AS dev
-COPY requirements-dev.txt /requirements-dev.txt
+COPY scan/requirements-dev.txt /requirements-dev.txt
 RUN pip install --no-cache-dir -r /requirements-dev.txt
-COPY tests/ /app/tests/
+COPY scan/tests/ /app/tests/
 WORKDIR /app
 ENTRYPOINT []
 CMD ["pytest"]

--- a/scan/Dockerfile
+++ b/scan/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 # Install the fetch package first — music_scan imports PendingRemovals from it.
 COPY fetch/music_fetch/ /app/fetch/music_fetch/
 COPY fetch/pyproject.toml /app/fetch/pyproject.toml
-RUN pip install --no-cache-dir -e /app/fetch
+RUN pip install --no-cache-dir /app/fetch
 
 # Python dependencies
 COPY scan/requirements.txt /requirements.txt

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -7,7 +7,6 @@ No Spotify or YouTube calls.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
@@ -16,6 +15,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from music_fetch.ingest import PendingRemovals
 from music_scan.library import MusicLibrary
 from music_scan.metrics import ScanMetrics
 from music_scan.navidrome import trigger_scan
@@ -29,7 +29,6 @@ QUARANTINE = Path("/root/Music/quarantine")
 PLAYLISTS = Path("/root/Music/playlists")
 INBOX = Path("/root/Music/inbox")
 LIBRARY_DB = Path("/root/.config/beets/library.db")
-PENDING_REMOVALS = Path("/root/Music/inbox/.pending-removals.json")
 
 
 _STOP_WORDS = frozenset({"the", "and", "for", "feat", "ft", "vs", "with", "a", "an", "of", "in", "on"})
@@ -106,77 +105,6 @@ def _quarantine_inbox_leftovers() -> int:
     return moved
 
 
-def _process_pending_removals() -> int:
-    """Clear beets source tags for tracks/playlists removed by the fetch container.
-
-    Reads .pending-removals.json from the shared volume, processes each entry,
-    then deletes the file.  Returns the number of entries processed.
-
-    Supports both formats:
-    - Old (list): [{title, artist, source}, ...]
-    - New (dict): {tracks: [{title, artist, source}], remove_sources: [name, ...]}
-    """
-    if not PENDING_REMOVALS.exists():
-        return 0
-
-    content = PENDING_REMOVALS.read_text(encoding="utf-8")
-    PENDING_REMOVALS.unlink()
-
-    try:
-        data = json.loads(content)
-    except json.JSONDecodeError:
-        logger.error(
-            "Discarded malformed .pending-removals.json — source-tag cleanup skipped. "
-            "Manually run `beet modify source= source:<name>` for affected playlists."
-        )
-        return 0
-
-    # Support old list format for backward compatibility.
-    if isinstance(data, list):
-        tracks: list[dict] = data
-        remove_sources: list[str] = []
-    else:
-        tracks = data.get("tracks", [])
-        remove_sources = data.get("remove_sources", [])
-
-    if not tracks and not remove_sources:
-        return 0
-
-    logger.info(
-        "==> Processing pending removals: %d track(s), %d source(s)...",
-        len(tracks),
-        len(remove_sources),
-    )
-    total = 0
-    with MusicLibrary(LIBRARY_DB) as lib:
-        for entry in tracks:
-            title = entry.get("title", "")
-            artist = entry.get("artist", "")
-            source = entry.get("source", "")
-            found = lib.clear_source_tag(title=title, artist=artist, source=source)
-            if not found:
-                logger.warning(
-                    "  WARNING: not found in beets — may need manual cleanup: %s by %s (source=%s)",
-                    title,
-                    artist,
-                    source,
-                )
-            total += 1
-
-        for source_name in remove_sources:
-            logger.info("==> Removing all tracks from playlist: %s", source_name)
-            items = lib.items_by_source(source_name)
-            for item in items:
-                item["source"] = ""
-                item.store()
-            m3u = PLAYLISTS / f"{source_name}.m3u"
-            m3u.unlink(missing_ok=True)
-            logger.info("  Cleared %d item(s) and removed .m3u for source=%s", len(items), source_name)
-            total += 1
-
-    return total
-
-
 _ASIS_REQUIRED_TAGS = ("title", "artist", "album", "tracknumber")
 
 
@@ -223,7 +151,7 @@ def _regen_playlists() -> None:
             m3u.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
-def run() -> None:
+def run(pending: PendingRemovals | None = None) -> None:
     """Execute the full scan pipeline, push metrics on completion."""
     metrics = ScanMetrics()
     start = time.monotonic()
@@ -231,8 +159,39 @@ def run() -> None:
     try:
         logger.info("==> music-scan starting")
 
-        logger.info("==> Processing pending removals from fetch container...")
-        metrics.tracks_removed = _process_pending_removals()
+        if pending is not None:
+            logger.info(
+                "==> Processing pending removals: %d track(s), %d source(s)...",
+                len(pending.tracks),
+                len(pending.remove_sources),
+            )
+            total = 0
+            with MusicLibrary(LIBRARY_DB) as lib:
+                for entry in pending.tracks:
+                    title = entry.get("title", "")
+                    artist = entry.get("artist", "")
+                    source = entry.get("source", "")
+                    found = lib.clear_source_tag(title=title, artist=artist, source=source)
+                    if not found:
+                        logger.warning(
+                            "  WARNING: not found in beets — may need manual cleanup: %s by %s (source=%s)",
+                            title,
+                            artist,
+                            source,
+                        )
+                    total += 1
+
+                for source_name in pending.remove_sources:
+                    logger.info("==> Removing all tracks from playlist: %s", source_name)
+                    items = lib.items_by_source(source_name)
+                    for item in items:
+                        item["source"] = ""
+                        item.store()
+                    m3u = PLAYLISTS / f"{source_name}.m3u"
+                    m3u.unlink(missing_ok=True)
+                    logger.info("  Cleared %d item(s) and removed .m3u for source=%s", len(items), source_name)
+                    total += 1
+            metrics.tracks_removed = total
 
         quarantined_before = _count_quarantine()
 

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -151,6 +151,39 @@ def _regen_playlists() -> None:
             m3u.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
+def _apply_pending_removals(pending: PendingRemovals, lib: MusicLibrary) -> int:
+    """Clear beets source tags for tracks and playlists in *pending*. Returns entry count."""
+    logger.info(
+        "==> Processing pending removals: %d track(s), %d source(s)...",
+        len(pending.tracks),
+        len(pending.remove_sources),
+    )
+    total = 0
+    for track in pending.tracks:
+        found = lib.clear_source_tag(title=track.title, artist=track.artist, source=track.source)
+        if not found:
+            logger.warning(
+                "  WARNING: not found in beets — may need manual cleanup: %s by %s (source=%s)",
+                track.title,
+                track.artist,
+                track.source,
+            )
+        total += 1
+
+    for source_name in pending.remove_sources:
+        logger.info("==> Removing all tracks from playlist: %s", source_name)
+        items = lib.items_by_source(source_name)
+        for item in items:
+            item["source"] = ""
+            item.store()
+        m3u = PLAYLISTS / f"{source_name}.m3u"
+        m3u.unlink(missing_ok=True)
+        logger.info("  Cleared %d item(s) and removed .m3u for source=%s", len(items), source_name)
+        total += 1
+
+    return total
+
+
 def run(pending: PendingRemovals | None = None) -> None:
     """Execute the full scan pipeline, push metrics on completion."""
     metrics = ScanMetrics()
@@ -159,39 +192,10 @@ def run(pending: PendingRemovals | None = None) -> None:
     try:
         logger.info("==> music-scan starting")
 
+        metrics.tracks_removed = 0
         if pending is not None:
-            logger.info(
-                "==> Processing pending removals: %d track(s), %d source(s)...",
-                len(pending.tracks),
-                len(pending.remove_sources),
-            )
-            total = 0
             with MusicLibrary(LIBRARY_DB) as lib:
-                for entry in pending.tracks:
-                    title = entry.get("title", "")
-                    artist = entry.get("artist", "")
-                    source = entry.get("source", "")
-                    found = lib.clear_source_tag(title=title, artist=artist, source=source)
-                    if not found:
-                        logger.warning(
-                            "  WARNING: not found in beets — may need manual cleanup: %s by %s (source=%s)",
-                            title,
-                            artist,
-                            source,
-                        )
-                    total += 1
-
-                for source_name in pending.remove_sources:
-                    logger.info("==> Removing all tracks from playlist: %s", source_name)
-                    items = lib.items_by_source(source_name)
-                    for item in items:
-                        item["source"] = ""
-                        item.store()
-                    m3u = PLAYLISTS / f"{source_name}.m3u"
-                    m3u.unlink(missing_ok=True)
-                    logger.info("  Cleared %d item(s) and removed .m3u for source=%s", len(items), source_name)
-                    total += 1
-            metrics.tracks_removed = total
+                metrics.tracks_removed = _apply_pending_removals(pending, lib)
 
         quarantined_before = _count_quarantine()
 

--- a/scan/pyproject.toml
+++ b/scan/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "music-pipeline-scan"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["music-pipeline-fetch"]
 
 [project.scripts]
 music-scan = "music_scan.cli:main"

--- a/scan/requirements.txt
+++ b/scan/requirements.txt
@@ -1,3 +1,4 @@
+-e ../fetch
 beets==2.8.0
 pyacoustid==1.3.0
 requests>=2.32

--- a/scan/requirements.txt
+++ b/scan/requirements.txt
@@ -1,4 +1,3 @@
--e ../fetch
 beets==2.8.0
 pyacoustid==1.3.0
 requests>=2.32

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -1,5 +1,6 @@
 """Tests for pipeline.scan — pure-Python logic."""
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -132,7 +133,7 @@ def test_run_with_pending_none_skips_removals(tmp_path: Path) -> None:
     mock_lib = _make_mock_lib()
     patches = _scan_run_patches(tmp_path, mock_lib)
 
-    with mock.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         for p in patches:
             stack.enter_context(p)
         scan.run(pending=None)
@@ -153,7 +154,7 @@ def test_run_with_pending_processes_track_removals(tmp_path: Path) -> None:
     mock_lib = _make_mock_lib()
     patches = _scan_run_patches(tmp_path, mock_lib)
 
-    with mock.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         for p in patches:
             stack.enter_context(p)
         scan.run(pending=pending)
@@ -179,7 +180,7 @@ def test_run_with_pending_processes_remove_sources(tmp_path: Path) -> None:
     mock_lib.items_by_source = mock.MagicMock(return_value=[mock_item])
     patches = _scan_run_patches(tmp_path, mock_lib)
 
-    with mock.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         for p in patches:
             stack.enter_context(p)
         scan.run(pending=pending)

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -1,6 +1,5 @@
 """Tests for pipeline.scan — pure-Python logic."""
 
-import contextlib
 import json
 import os
 from pathlib import Path
@@ -8,7 +7,7 @@ import unittest.mock as mock
 
 import pytest
 
-from music_fetch.ingest import PendingRemovals
+from music_fetch.ingest import PendingRemovals, RemovedTrack
 
 
 def _relative_path(track_path: Path, playlists_dir: Path) -> str:
@@ -85,7 +84,7 @@ def test_quarantine_leftovers(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# run() — PendingRemovals parameter
+# _apply_pending_removals
 # ---------------------------------------------------------------------------
 
 
@@ -100,95 +99,85 @@ def _make_mock_lib() -> mock.MagicMock:
     return mock_lib
 
 
-def _scan_run_patches(tmp_path: Path, mock_lib: mock.MagicMock) -> list:
-    """Return a list of context managers for the standard scan.run() test patches."""
-    inbox = tmp_path / "inbox"
-    inbox.mkdir(exist_ok=True)
-    spotdl_dir = tmp_path / "spotdl"
-    spotdl_dir.mkdir(exist_ok=True)
-    quarantine = tmp_path / "quarantine"
-    quarantine.mkdir(exist_ok=True)
-    playlists = tmp_path / "playlists"
-    playlists.mkdir(exist_ok=True)
-
-    return [
-        mock.patch("music_scan.scan.INBOX", inbox),
-        mock.patch("music_scan.scan.SPOTDL_DIR", spotdl_dir),
-        mock.patch("music_scan.scan.QUARANTINE", quarantine),
-        mock.patch("music_scan.scan.PLAYLISTS", playlists),
-        mock.patch("music_scan.scan.LIBRARY_DB", tmp_path / "library.db"),
-        mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib),
-        mock.patch("music_scan.scan.run_beet_import"),
-        mock.patch("music_scan.scan.run_beet_update"),
-        mock.patch("music_scan.scan.trigger_scan"),
-        mock.patch("music_scan.scan._move_asis_eligible", return_value=0),
-        mock.patch("music_scan.scan.ScanMetrics"),
-    ]
-
-
-def test_run_with_pending_none_skips_removals(tmp_path: Path) -> None:
-    """run(pending=None) completes without touching the library for removals."""
-    from music_scan import scan
-
-    mock_lib = _make_mock_lib()
-    patches = _scan_run_patches(tmp_path, mock_lib)
-
-    with contextlib.ExitStack() as stack:
-        for p in patches:
-            stack.enter_context(p)
-        scan.run(pending=None)
-
-    mock_lib.clear_source_tag.assert_not_called()
-    mock_lib.items_by_source.assert_not_called()
-
-
-def test_run_with_pending_processes_track_removals(tmp_path: Path) -> None:
-    """run(pending=PendingRemovals(...)) clears source tags for removed tracks."""
-    from music_scan import scan
+def test_apply_pending_removals_clears_source_tags(tmp_path: Path) -> None:
+    """Track removals call lib.clear_source_tag with typed fields."""
+    from music_scan.scan import _apply_pending_removals
 
     pending = PendingRemovals(
-        tracks=[{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}],
+        tracks=[RemovedTrack(title="Song A", artist="Artist 1", source="my-playlist")],
         remove_sources=[],
     )
-
     mock_lib = _make_mock_lib()
-    patches = _scan_run_patches(tmp_path, mock_lib)
 
-    with contextlib.ExitStack() as stack:
-        for p in patches:
-            stack.enter_context(p)
-        scan.run(pending=pending)
+    count = _apply_pending_removals(pending, mock_lib)
 
+    assert count == 1
     mock_lib.clear_source_tag.assert_called_once_with(
         title="Song A", artist="Artist 1", source="my-playlist"
     )
 
 
-def test_run_with_pending_processes_remove_sources(tmp_path: Path) -> None:
-    """run(pending=PendingRemovals(...)) removes all tracks from removed playlists."""
-    from music_scan import scan
+def test_apply_pending_removals_remove_sources(tmp_path: Path) -> None:
+    """Source removals call items_by_source, clear tags, and delete the .m3u."""
+    from music_scan.scan import _apply_pending_removals
 
     playlists = tmp_path / "playlists"
-    playlists.mkdir(exist_ok=True)
+    playlists.mkdir()
     m3u = playlists / "old-playlist.m3u"
     m3u.touch()
 
     pending = PendingRemovals(tracks=[], remove_sources=["old-playlist"])
-
     mock_item = mock.MagicMock()
     mock_lib = _make_mock_lib()
     mock_lib.items_by_source = mock.MagicMock(return_value=[mock_item])
-    patches = _scan_run_patches(tmp_path, mock_lib)
 
-    with contextlib.ExitStack() as stack:
-        for p in patches:
-            stack.enter_context(p)
-        scan.run(pending=pending)
+    with mock.patch("music_scan.scan.PLAYLISTS", playlists):
+        count = _apply_pending_removals(pending, mock_lib)
 
+    assert count == 1
     mock_lib.items_by_source.assert_called_once_with("old-playlist")
     mock_item.__setitem__.assert_called_once_with("source", "")
     mock_item.store.assert_called_once()
     assert not m3u.exists()
+
+
+def test_apply_pending_removals_returns_total_count() -> None:
+    """Return value is tracks + sources combined."""
+    from music_scan.scan import _apply_pending_removals
+
+    pending = PendingRemovals(
+        tracks=[
+            RemovedTrack(title="A", artist="X", source="pl1"),
+            RemovedTrack(title="B", artist="Y", source="pl2"),
+        ],
+        remove_sources=["gone-pl"],
+    )
+    mock_lib = _make_mock_lib()
+
+    with mock.patch("music_scan.scan.PLAYLISTS", mock.MagicMock()):
+        count = _apply_pending_removals(pending, mock_lib)
+
+    assert count == 3
+
+
+def test_run_with_pending_none_skips_apply(tmp_path: Path) -> None:
+    """run(pending=None) never calls _apply_pending_removals."""
+    from music_scan import scan
+
+    with mock.patch("music_scan.scan._apply_pending_removals") as mock_apply, \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=_make_mock_lib()), \
+         mock.patch("music_scan.scan.run_beet_import"), \
+         mock.patch("music_scan.scan.run_beet_update"), \
+         mock.patch("music_scan.scan.trigger_scan"), \
+         mock.patch("music_scan.scan._move_asis_eligible", return_value=0), \
+         mock.patch("music_scan.scan.INBOX", tmp_path), \
+         mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
+         mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.ScanMetrics"):
+        scan.run(pending=None)
+
+    mock_apply.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -7,6 +7,8 @@ import unittest.mock as mock
 
 import pytest
 
+from music_fetch.ingest import PendingRemovals
+
 
 def _relative_path(track_path: Path, playlists_dir: Path) -> str:
     """Replicate the relative-path logic used in _regen_playlists."""
@@ -82,173 +84,110 @@ def test_quarantine_leftovers(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _process_pending_removals — new {tracks, remove_sources} format
+# run() — PendingRemovals parameter
 # ---------------------------------------------------------------------------
 
 
-def test_process_pending_removals_no_file(tmp_path: Path) -> None:
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path):
-        count = _process_pending_removals()
-    assert count == 0
-
-
-def test_process_pending_removals_reads_and_deletes(tmp_path: Path) -> None:
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    data = {"tracks": [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}], "remove_sources": []}
-    fake_path.write_text(json.dumps(data), encoding="utf-8")
-
+def _make_mock_lib() -> mock.MagicMock:
     mock_lib = mock.MagicMock()
     mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
     mock_lib.__exit__ = mock.MagicMock(return_value=False)
     mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
+    mock_lib.items_by_source = mock.MagicMock(return_value=[])
+    mock_lib.items_added_since = mock.MagicMock(return_value=[])
+    mock_lib.paths_by_source = mock.MagicMock(return_value=[])
+    return mock_lib
 
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        count = _process_pending_removals()
 
-    assert count == 1
-    assert not fake_path.exists()
+def _scan_run_patches(tmp_path: Path, mock_lib: mock.MagicMock) -> list:
+    """Return a list of context managers for the standard scan.run() test patches."""
+    inbox = tmp_path / "inbox"
+    inbox.mkdir(exist_ok=True)
+    spotdl_dir = tmp_path / "spotdl"
+    spotdl_dir.mkdir(exist_ok=True)
+    quarantine = tmp_path / "quarantine"
+    quarantine.mkdir(exist_ok=True)
+    playlists = tmp_path / "playlists"
+    playlists.mkdir(exist_ok=True)
+
+    return [
+        mock.patch("music_scan.scan.INBOX", inbox),
+        mock.patch("music_scan.scan.SPOTDL_DIR", spotdl_dir),
+        mock.patch("music_scan.scan.QUARANTINE", quarantine),
+        mock.patch("music_scan.scan.PLAYLISTS", playlists),
+        mock.patch("music_scan.scan.LIBRARY_DB", tmp_path / "library.db"),
+        mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib),
+        mock.patch("music_scan.scan.run_beet_import"),
+        mock.patch("music_scan.scan.run_beet_update"),
+        mock.patch("music_scan.scan.trigger_scan"),
+        mock.patch("music_scan.scan._move_asis_eligible", return_value=0),
+        mock.patch("music_scan.scan.ScanMetrics"),
+    ]
+
+
+def test_run_with_pending_none_skips_removals(tmp_path: Path) -> None:
+    """run(pending=None) completes without touching the library for removals."""
+    from music_scan import scan
+
+    mock_lib = _make_mock_lib()
+    patches = _scan_run_patches(tmp_path, mock_lib)
+
+    with mock.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        scan.run(pending=None)
+
+    mock_lib.clear_source_tag.assert_not_called()
+    mock_lib.items_by_source.assert_not_called()
+
+
+def test_run_with_pending_processes_track_removals(tmp_path: Path) -> None:
+    """run(pending=PendingRemovals(...)) clears source tags for removed tracks."""
+    from music_scan import scan
+
+    pending = PendingRemovals(
+        tracks=[{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}],
+        remove_sources=[],
+    )
+
+    mock_lib = _make_mock_lib()
+    patches = _scan_run_patches(tmp_path, mock_lib)
+
+    with mock.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        scan.run(pending=pending)
+
     mock_lib.clear_source_tag.assert_called_once_with(
         title="Song A", artist="Artist 1", source="my-playlist"
     )
 
 
-def test_process_pending_removals_empty_data(tmp_path: Path) -> None:
-    from music_scan.scan import _process_pending_removals
+def test_run_with_pending_processes_remove_sources(tmp_path: Path) -> None:
+    """run(pending=PendingRemovals(...)) removes all tracks from removed playlists."""
+    from music_scan import scan
 
-    fake_path = tmp_path / ".pending-removals.json"
-    fake_path.write_text(json.dumps({"tracks": [], "remove_sources": []}), encoding="utf-8")
-
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path):
-        count = _process_pending_removals()
-
-    assert count == 0
-    assert not fake_path.exists()
-
-
-def test_process_pending_removals_malformed_json_deletes_file(tmp_path: Path) -> None:
-    """Malformed JSON must not leave the file in place (would break every future scan run)."""
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    fake_path.write_text("not valid json {{{{", encoding="utf-8")
-
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path):
-        count = _process_pending_removals()
-
-    assert count == 0
-    assert not fake_path.exists()  # file consumed even though JSON was invalid
-
-
-def test_process_pending_removals_multi_track(tmp_path: Path) -> None:
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    data = {
-        "tracks": [
-            {"title": "Song A", "artist": "Artist 1", "source": "playlist-1"},
-            {"title": "Song B", "artist": "Artist 2", "source": "playlist-2"},
-        ],
-        "remove_sources": [],
-    }
-    fake_path.write_text(json.dumps(data), encoding="utf-8")
-
-    mock_lib = mock.MagicMock()
-    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
-    mock_lib.__exit__ = mock.MagicMock(return_value=False)
-    mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
-
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        count = _process_pending_removals()
-
-    assert count == 2
-    assert not fake_path.exists()
-    assert mock_lib.clear_source_tag.call_count == 2
-
-
-def test_process_pending_removals_remove_sources(tmp_path: Path) -> None:
-    """remove_sources → items_by_source called, source tags cleared, .m3u deleted."""
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    playlists_dir = tmp_path / "playlists"
-    playlists_dir.mkdir()
-    m3u = playlists_dir / "old-playlist.m3u"
+    playlists = tmp_path / "playlists"
+    playlists.mkdir(exist_ok=True)
+    m3u = playlists / "old-playlist.m3u"
     m3u.touch()
 
-    data = {"tracks": [], "remove_sources": ["old-playlist"]}
-    fake_path.write_text(json.dumps(data), encoding="utf-8")
+    pending = PendingRemovals(tracks=[], remove_sources=["old-playlist"])
 
     mock_item = mock.MagicMock()
-    mock_lib = mock.MagicMock()
-    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
-    mock_lib.__exit__ = mock.MagicMock(return_value=False)
+    mock_lib = _make_mock_lib()
     mock_lib.items_by_source = mock.MagicMock(return_value=[mock_item])
+    patches = _scan_run_patches(tmp_path, mock_lib)
 
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
-         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        count = _process_pending_removals()
+    with mock.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        scan.run(pending=pending)
 
-    assert count == 1
-    assert not fake_path.exists()
     mock_lib.items_by_source.assert_called_once_with("old-playlist")
     mock_item.__setitem__.assert_called_once_with("source", "")
     mock_item.store.assert_called_once()
     assert not m3u.exists()
-
-
-def test_process_pending_removals_remove_source_missing_m3u(tmp_path: Path) -> None:
-    """remove_sources processing doesn't fail if .m3u doesn't exist."""
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    playlists_dir = tmp_path / "playlists"
-    playlists_dir.mkdir()
-
-    data = {"tracks": [], "remove_sources": ["gone-playlist"]}
-    fake_path.write_text(json.dumps(data), encoding="utf-8")
-
-    mock_lib = mock.MagicMock()
-    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
-    mock_lib.__exit__ = mock.MagicMock(return_value=False)
-    mock_lib.items_by_source = mock.MagicMock(return_value=[])
-
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
-         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        count = _process_pending_removals()
-
-    assert count == 1
-
-
-def test_process_pending_removals_backward_compat_old_list_format(tmp_path: Path) -> None:
-    """Old list format is still processed correctly."""
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    old_format = [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}]
-    fake_path.write_text(json.dumps(old_format), encoding="utf-8")
-
-    mock_lib = mock.MagicMock()
-    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
-    mock_lib.__exit__ = mock.MagicMock(return_value=False)
-    mock_lib.clear_source_tag = mock.MagicMock(return_value=True)
-
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        count = _process_pending_removals()
-
-    assert count == 1
-    mock_lib.clear_source_tag.assert_called_once_with(
-        title="Song A", artist="Artist 1", source="my-playlist"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -462,23 +401,3 @@ def test_run_beet_import_no_asis_flag_by_default() -> None:
     assert "--quiet" in cmd
 
 
-def test_process_pending_removals_file_deleted_before_processing(tmp_path: Path) -> None:
-    """File is unlinked before processing so an exception mid-processing doesn't re-block scans."""
-    from music_scan.scan import _process_pending_removals
-
-    fake_path = tmp_path / ".pending-removals.json"
-    data = {"tracks": [{"title": "Song A", "artist": "Artist 1", "source": "my-playlist"}], "remove_sources": []}
-    fake_path.write_text(json.dumps(data), encoding="utf-8")
-
-    mock_lib = mock.MagicMock()
-    mock_lib.__enter__ = mock.MagicMock(return_value=mock_lib)
-    mock_lib.__exit__ = mock.MagicMock(return_value=False)
-    mock_lib.clear_source_tag = mock.MagicMock(side_effect=RuntimeError("beets exploded"))
-
-    with mock.patch("music_scan.scan.PENDING_REMOVALS", fake_path), \
-         mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        with pytest.raises(RuntimeError):
-            _process_pending_removals()
-
-    # File was deleted before processing started — future scans are unblocked
-    assert not fake_path.exists()


### PR DESCRIPTION
## Summary

- Adds `PendingRemovals` dataclass to `music_fetch.ingest`
- `ingest.run()` returns `PendingRemovals` instead of writing `.pending-removals.json`
- `scan.run()` accepts `pending: PendingRemovals | None = None` and processes removals inline
- Removes `_write_pending_removals`, `_process_pending_removals`, and both `PENDING_REMOVALS` path constants
- Adds `music-pipeline-fetch` as a dependency of `music-pipeline-scan` (with `-e ../fetch` in requirements.txt for dev)

## Test plan

- [ ] `just test` — both suites pass
- [ ] No references to `.pending-removals.json` remain in Python code
- [ ] `music-ingest` standalone still works (return value discarded by CLI)
- [ ] `music-scan` standalone still works (`pending=None`, skips removals)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)