### PR TITLE
feat: unified Dockerfile, compose, and justfile

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         working-directory: fetch

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         working-directory: scan
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Python for integration tests
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Integration tests (scan)
         run: |

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -69,8 +69,8 @@ jobs:
           context: .
           file: service/Dockerfile
           target: prod
-          push: false
           load: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: |
             ${{ steps.meta.outputs.tags }}
             music-pipeline:ci-local
@@ -98,16 +98,3 @@ jobs:
 
       - name: Health check — fpcalc
         run: docker run --rm --entrypoint fpcalc music-pipeline:ci-local -version
-
-      - name: Push service image to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: service/Dockerfile
-          target: prod
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -1,16 +1,16 @@
-name: scan CI
+name: service CI
 
 on:
   push:
     branches: [main]
-    paths: ["fetch/**", "scan/**", "tests/**", "config/beets/**", "compose.yml", "justfile", ".github/workflows/scan.yml"]
+    paths: ["service/**", "fetch/**", "scan/**", "config/**", "compose.yml", "justfile", ".github/workflows/service.yml"]
   pull_request:
     branches: [main]
-    paths: ["fetch/**", "scan/**", "tests/**", "config/beets/**", "compose.yml", "justfile", ".github/workflows/scan.yml"]
+    paths: ["service/**", "fetch/**", "scan/**", "config/**", "compose.yml", "justfile", ".github/workflows/service.yml"]
 
 jobs:
   test:
-    name: Unit Tests (scan)
+    name: Unit Tests (service)
     runs-on: ubuntu-latest
 
     steps:
@@ -23,17 +23,17 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        working-directory: scan
         run: |
-          pip install -e ../fetch
-          pip install -r requirements.txt -r requirements-dev.txt -e .
+          pip install -e fetch
+          pip install -e scan
+          pip install -r service/requirements.txt -r service/requirements-dev.txt -e service
 
       - name: Run tests
-        working-directory: scan
+        working-directory: service
         run: pytest
 
   build-and-check:
-    name: Build, Health Check & Push (scan)
+    name: Build, Health Check & Push (service)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,58 +54,57 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (scan)
+      - name: Extract metadata (service)
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/music-pipeline-scan
+          images: ghcr.io/${{ github.repository_owner }}/music-pipeline
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,format=short
 
-      - name: Build scan image
+      - name: Build service image
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: scan/Dockerfile
+          file: service/Dockerfile
           target: prod
           push: false
           load: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            music-pipeline-scan:ci-local
+            music-pipeline:ci-local
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Health check — beet
-        run: docker run --rm --entrypoint beet music-pipeline-scan:ci-local version
+      - name: Health check — music-pipeline entry point
+        run: docker run --rm --entrypoint which music-pipeline:ci-local music-pipeline
 
-      - name: Health check — ffmpeg
-        run: docker run --rm --entrypoint ffmpeg music-pipeline-scan:ci-local -version
+      - name: Health check — music-ingest entry point
+        run: docker run --rm --entrypoint which music-pipeline:ci-local music-ingest
+
+      - name: Health check — music-scan entry point
+        run: docker run --rm --entrypoint which music-pipeline:ci-local music-scan
+
+      - name: Health check — rclone
+        run: docker run --rm --entrypoint rclone music-pipeline:ci-local version
+
+      - name: Health check — beet
+        run: docker run --rm --entrypoint beet music-pipeline:ci-local version
+
+      - name: Health check — spotdl
+        run: docker run --rm --entrypoint spotdl music-pipeline:ci-local --version
 
       - name: Health check — fpcalc
-        run: docker run --rm --entrypoint fpcalc music-pipeline-scan:ci-local -version
+        run: docker run --rm --entrypoint fpcalc music-pipeline:ci-local -version
 
-      - name: Health check — default command
-        run: docker run --rm --entrypoint which music-pipeline-scan:ci-local music-scan
-
-      - name: Set up Python for integration tests
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Integration tests (scan)
-        run: |
-          pip install -r tests/requirements.txt
-          SCAN_IMAGE=music-pipeline-scan:ci-local pytest tests/ -m "not auth" -v
-
-      - name: Push scan image to GHCR
+      - name: Push service image to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: scan/Dockerfile
+          file: service/Dockerfile
           target: prod
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/compose.yml
+++ b/compose.yml
@@ -1,48 +1,30 @@
 services:
-  fetch:
+  service:
     build:
-      context: fetch
+      context: .
+      dockerfile: service/Dockerfile
       target: prod
-    image: ghcr.io/sometimeskind/music-pipeline-fetch:latest
+    image: ghcr.io/sometimeskind/music-pipeline:latest
     volumes:
-      # Music data: inbox shared with scan container for downloaded files and pending-removals.json
       - /home/tom/Music:/root/Music
-      # spotdl config (from this repo)
+      - beets-data:/root/.config/beets
+      - ./config/beets/config.yaml:/root/.config/beets/config.yaml:ro
       - ./config/spotdl/config.json:/root/.config/spotdl/config.json:ro
-      # Playlist registry (from this repo; k8s: mount as ConfigMap)
       - ./config/playlists.conf:/root/.config/music-pipeline/playlists.conf:ro
       # YouTube Premium cookies — NOT committed; export from browser and place here
-      # See README for export instructions. Expires periodically.
       - ./cookies.txt:/root/.config/spotdl/cookies.txt:ro
     environment:
       # Inject Spotify credentials at runtime via: op run --env-file=.env.tpl -- docker compose run ...
       - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
-      # Optional: cap total new downloads per run across all playlists
+      - API_BEARER_TOKEN=${API_BEARER_TOKEN:-dev-token}
       - SYNC_TRACK_LIMIT=${SYNC_TRACK_LIMIT:-}
-      # Optional: random delay before syncing to spread load (seconds)
       - SYNC_JITTER_SECONDS=${SYNC_JITTER_SECONDS:-}
-      # Optional: Prometheus Pushgateway URL for job metrics
       - PUSHGATEWAY_URL=${PUSHGATEWAY_URL:-}
-
-  scan:
-    build:
-      context: .
-      dockerfile: scan/Dockerfile
-      target: prod
-    image: ghcr.io/sometimeskind/music-pipeline-scan:latest
-    volumes:
-      # Music data: inbox shared with fetch container, plus library/quarantine/playlists
-      - /home/tom/Music:/root/Music
-      # Beets database and import log (SQLite — back this up)
-      - beets-data:/root/.config/beets
-      # Beets config (from this repo)
-      - ./config/beets/config.yaml:/root/.config/beets/config.yaml:ro
-    environment:
-      # Optional: Prometheus Pushgateway URL for job metrics
-      - PUSHGATEWAY_URL=${PUSHGATEWAY_URL:-}
-      # Optional: stop beet import after N skips (for threshold testing)
       - BEET_SKIP_LIMIT=${BEET_SKIP_LIMIT:-}
+      - LIBRARY_REMOTE=${LIBRARY_REMOTE:-}
+    ports:
+      - "8080:8080"
 
 volumes:
   beets-data:

--- a/justfile
+++ b/justfile
@@ -4,6 +4,12 @@ test:
     docker run --rm music-pipeline-fetch:dev
     docker build --target dev -f scan/Dockerfile -t music-pipeline-scan:dev .
     docker run --rm music-pipeline-scan:dev
+    docker build --target dev -f service/Dockerfile -t music-pipeline-service:dev .
+    docker run --rm music-pipeline-service:dev
+
+# Build the unified service image
+build:
+    docker build -f service/Dockerfile -t music-pipeline:local .
 
 # Run container integration tests against the current GHCR image (no auth needed)
 # Override the image with: SCAN_IMAGE=music-pipeline-scan:local just test-integration
@@ -23,19 +29,19 @@ test-auth:
 hooks:
     git config core.hooksPath .githooks
 
-# Run spotdl sync (fetch container: Spotify/YouTube → inbox)
+# Run spotdl sync (fetch via service container)
 fetch:
-    op run --env-file .env.tpl -- docker compose run --rm fetch
+    op run --env-file .env.tpl -- docker compose run --rm service music-ingest
 
-# Run a local scan: import inbox → .m3u (no Spotify/YouTube)
+# Run a local scan
 scan:
-    docker compose run --rm scan
+    docker compose run --rm service music-scan
 
-# Run full ingest: spotdl sync → import → .m3u
+# Run full ingest
 sync:
     just fetch && just scan
 
 # Dump beets DB and export JSON from the container
 backup:
-    docker compose run --rm scan sh -c "beet export > /root/.config/beets/library-export.json"
-    docker compose run --rm scan sh -c "sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"
+    docker compose run --rm service sh -c "beet export > /root/.config/beets/library-export.json"
+    docker compose run --rm service sh -c "sqlite3 /root/.config/beets/library.db .dump > /root/.config/beets/library-dump.sql"

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,0 +1,48 @@
+# service: unified music-pipeline — fetch + scan + HTTP API
+# Build context: repo root
+FROM python:3.13-slim AS prod
+
+# System deps: all of fetch (ffmpeg, nodejs) + scan (ffmpeg, chromaprint) + rclone
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ffmpeg nodejs libchromaprint-tools rclone \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install all three packages
+COPY fetch/music_fetch/ /build/fetch/music_fetch/
+COPY fetch/pyproject.toml /build/fetch/pyproject.toml
+COPY fetch/requirements.txt /build/fetch/requirements.txt
+RUN pip install --no-cache-dir -r /build/fetch/requirements.txt /build/fetch
+
+COPY scan/music_scan/ /build/scan/music_scan/
+COPY scan/pyproject.toml /build/scan/pyproject.toml
+COPY scan/requirements.txt /build/scan/requirements.txt
+RUN pip install --no-cache-dir -r /build/scan/requirements.txt /build/scan
+
+COPY service/music_service/ /build/service/music_service/
+COPY service/pyproject.toml /build/service/pyproject.toml
+COPY service/requirements.txt /build/service/requirements.txt
+RUN pip install --no-cache-dir -r /build/service/requirements.txt /build/service
+
+# Pre-create directories
+RUN mkdir -p \
+    /root/Music/inbox/spotdl \
+    /root/Music/staging \
+    /root/Music/quarantine \
+    /root/Music/playlists \
+    /root/.config/beets \
+    /root/.config/spotdl \
+    /root/.config/music-pipeline \
+    /root/.config/yt-dlp
+
+RUN echo --js-runtimes node > /root/.config/yt-dlp/config
+
+CMD ["music-pipeline"]
+
+FROM prod AS dev
+COPY service/requirements-dev.txt /tmp/reqs-dev.txt
+RUN pip install --no-cache-dir -r /tmp/reqs-dev.txt
+COPY service/tests/ /app/tests/
+WORKDIR /app
+ENTRYPOINT []
+CMD ["pytest"]


### PR DESCRIPTION
Closes #68.

## Summary

- **`service/Dockerfile`** — new unified image installs fetch + scan + service packages; includes rclone; prod + dev stages; CMD is `music-pipeline`
- **`compose.yml`** — replaces `fetch` + `scan` services with single `service` container; adds `API_BEARER_TOKEN` and `LIBRARY_REMOTE` env vars; exposes port 8080
- **`justfile`** — `test` now builds/runs all three dev containers; new `build` recipe for the unified image; `fetch`, `scan`, `backup` updated to target the `service` container
- **`.github/workflows/service.yml`** — new CI workflow: unit tests + build + 7 health checks + GHCR push on main
- **`.github/workflows/scan.yml`** — adds `fetch/**` to paths trigger (scan depends on fetch)

## Test plan

- [ ] `just test` builds and runs fetch, scan, and service dev containers
- [ ] `just build` produces a working unified image
- [ ] `just fetch` / `just scan` / `just sync` target the service container
- [ ] CI: service workflow runs on PR and pushes to GHCR on main
- [ ] Existing fetch and scan CI workflows continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)