### PR TITLE
feat: add scripts/music-files CLI client (#67)

### DIFF
--- a/scripts/music-files
+++ b/scripts/music-files
@@ -57,7 +57,6 @@ def _human_size(n: int) -> str:
         n /= 1024.0
         if n < 1024 or unit == "GB":
             return f"{n:.1f} {unit}"
-    return f"{n:.1f} GB"  # unreachable but satisfies type checker
 
 
 def _print_table(files: list[dict]) -> None:
@@ -124,7 +123,7 @@ def cmd_upload(path: str) -> None:
     try:
         resp = requests.post(
             _url("/inbox/upload"),
-            headers=_headers(),
+            headers={**_headers(), "Content-Type": "application/zip"},
             data=buf.read(),
         )
     except requests.ConnectionError as e:

--- a/scripts/music-files
+++ b/scripts/music-files
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""CLI client for the music-pipeline HTTP API.
+
+Reads from environment:
+  MUSIC_PIPELINE_URL   — base URL (e.g. http://music-pipeline.prins.id:8080)
+  MUSIC_PIPELINE_TOKEN — bearer token
+
+Usage:
+  music-files list-inbox
+  music-files list-quarantine
+  music-files upload <path>
+  music-files download <path>
+  music-files trigger-fetch
+  music-files trigger-scan
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _url(path: str) -> str:
+    """Build full URL from env base + path."""
+    base = os.environ.get("MUSIC_PIPELINE_URL", "").rstrip("/")
+    if not base:
+        print("ERROR: MUSIC_PIPELINE_URL is not set", file=sys.stderr)
+        sys.exit(1)
+    return base + path
+
+
+def _headers() -> dict:
+    """Return Authorization header dict."""
+    token = os.environ.get("MUSIC_PIPELINE_TOKEN", "")
+    if not token:
+        print("ERROR: MUSIC_PIPELINE_TOKEN is not set", file=sys.stderr)
+        sys.exit(1)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _human_size(n: int) -> str:
+    """Convert bytes to human-readable string."""
+    if n < 1024:
+        return f"{n} B"
+    for unit in ("KB", "MB", "GB"):
+        n /= 1024.0
+        if n < 1024 or unit == "GB":
+            return f"{n:.1f} {unit}"
+    return f"{n:.1f} GB"  # unreachable but satisfies type checker
+
+
+def _print_table(files: list[dict]) -> None:
+    """Print file listing as aligned columns: name, size, modified."""
+    if not files:
+        return
+    col_name = max(len(f["name"]) for f in files)
+    col_size = max(len(_human_size(f["size"])) for f in files)
+    for f in files:
+        name = f["name"].ljust(col_name)
+        size = _human_size(f["size"]).rjust(col_size)
+        modified = f["modified"]
+        print(f"{name}  {size}  {modified}")
+
+
+def _check_response(resp: requests.Response) -> None:
+    """Exit 1 if response is not 2xx."""
+    if not (200 <= resp.status_code < 300):
+        print(f"ERROR: HTTP {resp.status_code}: {resp.text}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_list_inbox() -> None:
+    try:
+        resp = requests.get(_url("/inbox"), headers=_headers())
+    except requests.ConnectionError as e:
+        print(f"ERROR: Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    _check_response(resp)
+    _print_table(resp.json())
+
+
+def cmd_list_quarantine() -> None:
+    try:
+        resp = requests.get(_url("/quarantine"), headers=_headers())
+    except requests.ConnectionError as e:
+        print(f"ERROR: Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    _check_response(resp)
+    _print_table(resp.json())
+
+
+def cmd_upload(path: str) -> None:
+    target = Path(path)
+    if not target.exists():
+        print(f"ERROR: path not found: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        if target.is_file():
+            zf.write(target, target.name)
+        else:
+            for f in sorted(target.rglob("*")):
+                if f.is_file():
+                    zf.write(f, f.relative_to(target))
+    buf.seek(0)
+
+    try:
+        resp = requests.post(
+            _url("/inbox/upload"),
+            headers=_headers(),
+            data=buf.read(),
+        )
+    except requests.ConnectionError as e:
+        print(f"ERROR: Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    _check_response(resp)
+    print(f"Uploaded {path}")
+
+
+def cmd_download(path: str) -> None:
+    try:
+        resp = requests.get(_url(f"/quarantine/download/{path}"), headers=_headers())
+    except requests.ConnectionError as e:
+        print(f"ERROR: Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    _check_response(resp)
+
+    content_type = resp.headers.get("Content-Type", "")
+    if "application/zip" in content_type:
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            zf.extractall(".")
+        print(f"Extracted {path}.zip in current directory")
+    else:
+        filename = Path(path).name
+        with open(filename, "wb") as fh:
+            fh.write(resp.content)
+        print(f"Saved {filename}")
+
+
+def cmd_trigger_fetch() -> None:
+    try:
+        resp = requests.post(_url("/fetch/trigger"), headers=_headers())
+    except requests.ConnectionError as e:
+        print(f"ERROR: Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    if resp.status_code == 202:
+        print("Fetch started")
+    elif resp.status_code == 409:
+        print("Pipeline busy")
+    else:
+        print(f"ERROR: HTTP {resp.status_code}: {resp.text}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_trigger_scan() -> None:
+    try:
+        resp = requests.post(_url("/scan/trigger"), headers=_headers())
+    except requests.ConnectionError as e:
+        print(f"ERROR: Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    if resp.status_code == 202:
+        print("Scan started")
+    elif resp.status_code == 409:
+        print("Pipeline busy")
+    else:
+        print(f"ERROR: HTTP {resp.status_code}: {resp.text}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="music-pipeline API client")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list-inbox", help="List inbox files")
+    sub.add_parser("list-quarantine", help="List quarantine files")
+
+    p_upload = sub.add_parser("upload", help="Upload a file or directory")
+    p_upload.add_argument("path", help="Local file or directory to upload")
+
+    p_download = sub.add_parser("download", help="Download from quarantine")
+    p_download.add_argument("path", help="Remote path to download")
+
+    sub.add_parser("trigger-fetch", help="Trigger a fetch run")
+    sub.add_parser("trigger-scan", help="Trigger a scan run")
+
+    args = parser.parse_args()
+
+    if args.command == "list-inbox":
+        cmd_list_inbox()
+    elif args.command == "list-quarantine":
+        cmd_list_quarantine()
+    elif args.command == "upload":
+        cmd_upload(args.path)
+    elif args.command == "download":
+        cmd_download(args.path)
+    elif args.command == "trigger-fetch":
+        cmd_trigger_fetch()
+    elif args.command == "trigger-scan":
+        cmd_trigger_scan()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_music_files.py
+++ b/scripts/tests/test_music_files.py
@@ -65,7 +65,7 @@ def test_human_size_gb(mod):
 def test_print_table_empty(mod, capsys):
     mod._print_table([])
     out = capsys.readouterr().out
-    assert out == "" or "name" in out.lower() or out == "\n"
+    assert out == ""
 
 
 def test_print_table_aligns_columns(mod, capsys):
@@ -161,6 +161,13 @@ def test_list_quarantine_prints_table(mod, capsys):
         mod.cmd_list_quarantine()
     out = capsys.readouterr().out
     assert "bad.m4a" in out
+
+
+def test_list_quarantine_connection_error_exits(mod):
+    with patch("requests.get", side_effect=requests.ConnectionError("refused")):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_list_quarantine()
+    assert exc_info.value.code == 1
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +284,13 @@ def test_download_http_error_exits(mod):
     assert exc_info.value.code == 1
 
 
+def test_download_connection_error_exits(mod):
+    with patch("requests.get", side_effect=requests.ConnectionError("refused")):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_download("bad.m4a")
+    assert exc_info.value.code == 1
+
+
 # ---------------------------------------------------------------------------
 # trigger-fetch
 # ---------------------------------------------------------------------------
@@ -290,7 +304,7 @@ def test_trigger_fetch_accepted(mod, capsys):
         mod.cmd_trigger_fetch()
 
     out = capsys.readouterr().out
-    assert "fetch" in out.lower() or "started" in out.lower() or "accepted" in out.lower()
+    assert out == "Fetch started\n"
 
 
 def test_trigger_fetch_busy(mod, capsys):
@@ -301,7 +315,7 @@ def test_trigger_fetch_busy(mod, capsys):
         mod.cmd_trigger_fetch()
 
     out = capsys.readouterr().out
-    assert "busy" in out.lower() or "pipeline" in out.lower()
+    assert out == "Pipeline busy\n"
 
 
 def test_trigger_fetch_error_exits(mod):
@@ -328,7 +342,7 @@ def test_trigger_scan_accepted(mod, capsys):
         mod.cmd_trigger_scan()
 
     out = capsys.readouterr().out
-    assert "scan" in out.lower() or "started" in out.lower() or "accepted" in out.lower()
+    assert out == "Scan started\n"
 
 
 def test_trigger_scan_busy(mod, capsys):
@@ -339,7 +353,18 @@ def test_trigger_scan_busy(mod, capsys):
         mod.cmd_trigger_scan()
 
     out = capsys.readouterr().out
-    assert "busy" in out.lower() or "pipeline" in out.lower()
+    assert out == "Pipeline busy\n"
+
+
+def test_trigger_scan_error_exits(mod):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+    mock_resp.text = "Server Error"
+
+    with patch("requests.post", return_value=mock_resp):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_trigger_scan()
+    assert exc_info.value.code == 1
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_music_files.py
+++ b/scripts/tests/test_music_files.py
@@ -1,0 +1,361 @@
+"""Tests for scripts/music-files CLI client."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Load the script as a module (it has no .py extension)
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = Path(__file__).parent.parent / "music-files"
+
+
+@pytest.fixture(scope="session")
+def mod():
+    spec = importlib.util.spec_from_file_location("music_files", SCRIPT_PATH)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture(autouse=True)
+def default_env(monkeypatch):
+    monkeypatch.setenv("MUSIC_PIPELINE_URL", "http://localhost:8080")
+    monkeypatch.setenv("MUSIC_PIPELINE_TOKEN", "test-token")
+
+
+# ---------------------------------------------------------------------------
+# _human_size
+# ---------------------------------------------------------------------------
+
+
+def test_human_size_bytes(mod):
+    assert mod._human_size(0) == "0 B"
+    assert mod._human_size(999) == "999 B"
+
+
+def test_human_size_kb(mod):
+    assert mod._human_size(1024) == "1.0 KB"
+    assert mod._human_size(2048) == "2.0 KB"
+
+
+def test_human_size_mb(mod):
+    assert mod._human_size(1024 * 1024) == "1.0 MB"
+
+
+def test_human_size_gb(mod):
+    assert mod._human_size(1024 ** 3) == "1.0 GB"
+
+
+# ---------------------------------------------------------------------------
+# _print_table
+# ---------------------------------------------------------------------------
+
+
+def test_print_table_empty(mod, capsys):
+    mod._print_table([])
+    out = capsys.readouterr().out
+    assert out == "" or "name" in out.lower() or out == "\n"
+
+
+def test_print_table_aligns_columns(mod, capsys):
+    files = [
+        {"name": "a.m4a", "size": 1024, "modified": "2024-01-01T00:00:00+00:00"},
+        {"name": "long-name.m4a", "size": 2048 * 1024, "modified": "2024-06-15T12:30:00+00:00"},
+    ]
+    mod._print_table(files)
+    out = capsys.readouterr().out
+    lines = [l for l in out.splitlines() if l.strip()]
+    assert len(lines) == 2
+    assert "a.m4a" in out
+    assert "long-name.m4a" in out
+    assert "1.0 KB" in out
+    assert "2.0 MB" in out
+
+
+# ---------------------------------------------------------------------------
+# _url and _headers
+# ---------------------------------------------------------------------------
+
+
+def test_url_builds_correctly(mod):
+    assert mod._url("/inbox") == "http://localhost:8080/inbox"
+
+
+def test_url_no_double_slash(mod):
+    result = mod._url("/health")
+    assert "//" not in result.replace("http://", "")
+
+
+def test_headers_contains_bearer(mod):
+    h = mod._headers()
+    assert h["Authorization"] == "Bearer test-token"
+
+
+# ---------------------------------------------------------------------------
+# list-inbox
+# ---------------------------------------------------------------------------
+
+
+def test_list_inbox_prints_table(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = [
+        {"name": "song.m4a", "size": 5120, "modified": "2024-03-01T10:00:00+00:00"}
+    ]
+    with patch("requests.get", return_value=mock_resp):
+        mod.cmd_list_inbox()
+    out = capsys.readouterr().out
+    assert "song.m4a" in out
+    assert "5.0 KB" in out
+
+
+def test_list_inbox_empty(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = []
+    with patch("requests.get", return_value=mock_resp):
+        mod.cmd_list_inbox()
+    # Should not raise; empty output or empty table is fine
+
+
+def test_list_inbox_http_error_exits(mod):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+    mock_resp.text = "Unauthorized"
+    with patch("requests.get", return_value=mock_resp):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_list_inbox()
+    assert exc_info.value.code == 1
+
+
+def test_list_inbox_connection_error_exits(mod):
+    with patch("requests.get", side_effect=requests.ConnectionError("refused")):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_list_inbox()
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# list-quarantine
+# ---------------------------------------------------------------------------
+
+
+def test_list_quarantine_prints_table(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = [
+        {"name": "bad.m4a", "size": 1024, "modified": "2024-04-01T00:00:00+00:00"}
+    ]
+    with patch("requests.get", return_value=mock_resp):
+        mod.cmd_list_quarantine()
+    out = capsys.readouterr().out
+    assert "bad.m4a" in out
+
+
+# ---------------------------------------------------------------------------
+# upload
+# ---------------------------------------------------------------------------
+
+
+def test_upload_file(mod, tmp_path, capsys):
+    audio = tmp_path / "track.m4a"
+    audio.write_bytes(b"fake-audio-data")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("requests.post", return_value=mock_resp) as mock_post:
+        mod.cmd_upload(str(audio))
+
+    args, kwargs = mock_post.call_args
+    # The body should be valid zip bytes
+    body = kwargs.get("data") or args[1]
+    zf = zipfile.ZipFile(io.BytesIO(body))
+    assert "track.m4a" in zf.namelist()
+
+    out = capsys.readouterr().out
+    assert out.strip()  # some confirmation message
+
+
+def test_upload_directory(mod, tmp_path, capsys):
+    d = tmp_path / "playlist"
+    d.mkdir()
+    (d / "a.m4a").write_bytes(b"aaa")
+    (d / "b.m4a").write_bytes(b"bbb")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("requests.post", return_value=mock_resp) as mock_post:
+        mod.cmd_upload(str(d))
+
+    args, kwargs = mock_post.call_args
+    body = kwargs.get("data") or args[1]
+    zf = zipfile.ZipFile(io.BytesIO(body))
+    names = zf.namelist()
+    assert "a.m4a" in names
+    assert "b.m4a" in names
+
+
+def test_upload_http_error_exits(mod, tmp_path):
+    audio = tmp_path / "track.m4a"
+    audio.write_bytes(b"x")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+    mock_resp.text = "Internal Server Error"
+
+    with patch("requests.post", return_value=mock_resp):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_upload(str(audio))
+    assert exc_info.value.code == 1
+
+
+def test_upload_nonexistent_path_exits(mod):
+    with pytest.raises(SystemExit) as exc_info:
+        mod.cmd_upload("/nonexistent/path/to/file.m4a")
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# download
+# ---------------------------------------------------------------------------
+
+
+def test_download_plain_file_saved_to_cwd(mod, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {"Content-Type": "audio/mp4"}
+    mock_resp.content = b"audio-bytes"
+
+    with patch("requests.get", return_value=mock_resp):
+        mod.cmd_download("bad.m4a")
+
+    assert (tmp_path / "bad.m4a").read_bytes() == b"audio-bytes"
+
+
+def test_download_zip_extracted_in_cwd(mod, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("album/track1.m4a", b"t1")
+    buf.seek(0)
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.headers = {"Content-Type": "application/zip"}
+    mock_resp.content = buf.read()
+
+    with patch("requests.get", return_value=mock_resp):
+        mod.cmd_download("album")
+
+    assert (tmp_path / "album" / "track1.m4a").exists()
+
+
+def test_download_http_error_exits(mod):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_resp.text = "not found"
+
+    with patch("requests.get", return_value=mock_resp):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_download("missing.m4a")
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# trigger-fetch
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_fetch_accepted(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 202
+
+    with patch("requests.post", return_value=mock_resp):
+        mod.cmd_trigger_fetch()
+
+    out = capsys.readouterr().out
+    assert "fetch" in out.lower() or "started" in out.lower() or "accepted" in out.lower()
+
+
+def test_trigger_fetch_busy(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 409
+
+    with patch("requests.post", return_value=mock_resp):
+        mod.cmd_trigger_fetch()
+
+    out = capsys.readouterr().out
+    assert "busy" in out.lower() or "pipeline" in out.lower()
+
+
+def test_trigger_fetch_error_exits(mod):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+    mock_resp.text = "Server Error"
+
+    with patch("requests.post", return_value=mock_resp):
+        with pytest.raises(SystemExit) as exc_info:
+            mod.cmd_trigger_fetch()
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# trigger-scan
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_scan_accepted(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 202
+
+    with patch("requests.post", return_value=mock_resp):
+        mod.cmd_trigger_scan()
+
+    out = capsys.readouterr().out
+    assert "scan" in out.lower() or "started" in out.lower() or "accepted" in out.lower()
+
+
+def test_trigger_scan_busy(mod, capsys):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 409
+
+    with patch("requests.post", return_value=mock_resp):
+        mod.cmd_trigger_scan()
+
+    out = capsys.readouterr().out
+    assert "busy" in out.lower() or "pipeline" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Missing environment variables
+# ---------------------------------------------------------------------------
+
+
+def test_missing_url_exits(mod, monkeypatch):
+    monkeypatch.delenv("MUSIC_PIPELINE_URL")
+    with pytest.raises(SystemExit) as exc_info:
+        mod.cmd_list_inbox()
+    assert exc_info.value.code == 1
+
+
+def test_missing_token_exits(mod, monkeypatch):
+    monkeypatch.delenv("MUSIC_PIPELINE_TOKEN")
+    with pytest.raises(SystemExit) as exc_info:
+        mod.cmd_list_inbox()
+    assert exc_info.value.code == 1

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -43,6 +43,7 @@ FROM prod AS dev
 COPY service/requirements-dev.txt /tmp/reqs-dev.txt
 RUN pip install --no-cache-dir -r /tmp/reqs-dev.txt
 COPY service/tests/ /app/tests/
+COPY scripts/ /app/scripts/
 WORKDIR /app
 ENTRYPOINT []
-CMD ["pytest"]
+CMD ["pytest", "tests/", "scripts/tests/"]


### PR DESCRIPTION
## Summary

- Adds `scripts/music-files`: standalone executable Python script (stdlib + `requests`) for interacting with the music-pipeline HTTP API
- Subcommands: `list-inbox`, `list-quarantine`, `upload <path>`, `download <path>`, `trigger-fetch`, `trigger-scan`
- Reads `MUSIC_PIPELINE_URL` and `MUSIC_PIPELINE_TOKEN` from environment; exits 1 with a clear message if either is missing
- Adds `scripts/tests/test_music_files.py` (28 tests) covering all subcommands, error paths, and helpers — the issue said no tests needed but tests were requested
- Updates `service/Dockerfile` dev stage to copy `scripts/` and run both `tests/` and `scripts/tests/` under CI

## Test Plan

- [ ] CI passes (`just test` in service container covers `scripts/tests/`)
- [ ] `list-inbox` and `list-quarantine` print aligned table
- [ ] `upload` accepts both a file and a directory
- [ ] `download` saves a plain file to CWD and extracts a zip in CWD
- [ ] `trigger-fetch` / `trigger-scan` print "Fetch/Scan started" (202) or "Pipeline busy" (409)
- [ ] Missing env vars exit 1 with error message

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)