### PR TITLE
feat: reconcile .spotdl snapshots against beets library after each scan

### DIFF
--- a/scan/music_scan/reconcile.py
+++ b/scan/music_scan/reconcile.py
@@ -1,0 +1,153 @@
+"""Reconcile .spotdl snapshots against the beets library.
+
+After each scan, URLs in the snapshot that are absent from both the beets
+library and the quarantine directory are dropped. This allows spotdl to
+re-download them on the next fetch run rather than silently skipping them
+forever.
+
+Called by the orchestrator after every scan, before the library push.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from music_scan.library import MusicLibrary
+
+logger = logging.getLogger(__name__)
+
+SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
+LIBRARY_DB = Path("/root/.config/beets/library.db")
+QUARANTINE_DIR = Path("/root/Music/quarantine")
+
+
+def _read_spotify_url(path: Path) -> str | None:
+    """Return the Spotify URL embedded in an M4A file by spotdl, or None."""
+    try:
+        from mutagen.mp4 import MP4  # noqa: PLC0415 — beets dep, always available
+
+        audio = MP4(str(path))
+        raw = (audio.tags or {}).get("----:spotdl:WOAS")
+        if raw:
+            return raw[0].decode("utf-8")
+    except Exception:
+        pass
+    return None
+
+
+def _quarantine_urls(quarantine_dir: Path) -> frozenset[str]:
+    """Return the set of Spotify URLs found in the quarantine directory."""
+    urls: set[str] = set()
+    for m4a in quarantine_dir.rglob("*.m4a"):
+        url = _read_spotify_url(m4a)
+        if url:
+            urls.add(url)
+    return frozenset(urls)
+
+
+def reconcile_snapshot(
+    spotdl_file: Path,
+    library: "MusicLibrary",
+    safe_urls: frozenset[str] | set[str] = frozenset(),
+) -> int:
+    """Diff one .spotdl snapshot against the beets library.
+
+    *safe_urls* is the union of library-verified URLs and quarantine URLs
+    (pre-computed by the caller so the quarantine is only scanned once).
+
+    Drops snapshot entries whose URL is absent from *safe_urls*, logging a
+    WARNING for each. Returns the count of dropped URLs.
+    """
+    with open(spotdl_file, encoding="utf-8") as fh:
+        sync_data = json.load(fh)
+
+    songs = sync_data.get("songs", [])
+    if not songs:
+        return 0
+
+    playlist_name = spotdl_file.stem
+
+    # Build verified URL set from beets library paths for this playlist.
+    library_urls: set[str] = set()
+    for path in library.paths_by_source(playlist_name):
+        if not path.exists():
+            logger.warning("Beets has stale path for %s: %s", playlist_name, path)
+            continue
+        url = _read_spotify_url(path)
+        if url:
+            library_urls.add(url)
+        else:
+            logger.warning("Could not read Spotify URL from library file: %s", path)
+
+    all_safe = library_urls | safe_urls
+
+    kept: list[dict] = []
+    dropped = 0
+    for song in songs:
+        url = song.get("url", "")
+        if url and url not in all_safe:
+            logger.warning(
+                "Dropping stale URL from %s snapshot (absent from library and quarantine): %s",
+                playlist_name,
+                url,
+            )
+            dropped += 1
+        else:
+            kept.append(song)
+
+    if dropped:
+        sync_data["songs"] = kept
+        with open(spotdl_file, "w", encoding="utf-8") as fh:
+            json.dump(sync_data, fh, indent=4, ensure_ascii=False)
+
+    return dropped
+
+
+def reconcile_all(
+    spotdl_dir: Path = SPOTDL_DIR,
+    library_db: Path = LIBRARY_DB,
+    quarantine_dir: Path = QUARANTINE_DIR,
+) -> int:
+    """Reconcile all .spotdl snapshots against the beets library.
+
+    Scans the quarantine directory once, then verifies each snapshot.
+    Skips silently if library_db does not exist (e.g. first run).
+    Returns the total number of URLs dropped across all playlists.
+    """
+    from music_scan.library import MusicLibrary  # noqa: PLC0415 — deferred; beets not always present
+
+    if not library_db.exists():
+        logger.info("Beets library.db not found — skipping reconciliation")
+        return 0
+
+    spotdl_files = sorted(spotdl_dir.glob("*.spotdl"))
+    if not spotdl_files:
+        return 0
+
+    q_urls = _quarantine_urls(quarantine_dir)
+    if q_urls:
+        logger.debug("Quarantine contains %d known Spotify URL(s)", len(q_urls))
+
+    total_dropped = 0
+    with MusicLibrary(db_path=library_db) as lib:
+        for spotdl_file in spotdl_files:
+            try:
+                dropped = reconcile_snapshot(spotdl_file, lib, q_urls)
+                total_dropped += dropped
+            except Exception:
+                logger.exception("Failed to reconcile snapshot: %s", spotdl_file.name)
+
+    if total_dropped:
+        logger.warning(
+            "Reconciliation: dropped %d stale URL(s) across %d playlist(s) — will re-download next fetch",
+            total_dropped,
+            len(spotdl_files),
+        )
+    else:
+        logger.info("Reconciliation: all snapshot URLs verified against beets library")
+
+    return total_dropped

--- a/scan/tests/test_reconcile.py
+++ b/scan/tests/test_reconcile.py
@@ -1,0 +1,194 @@
+"""Tests for music_scan.reconcile — pure-Python logic (no beets process, no network)."""
+
+from __future__ import annotations
+
+import json
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+from music_scan.reconcile import reconcile_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_snapshot(path: Path, playlist_name: str, urls: list[str]) -> Path:
+    spotdl_file = path / f"{playlist_name}.spotdl"
+    songs = [{"url": url, "name": f"Track {i}", "artists": ["Artist"]} for i, url in enumerate(urls)]
+    spotdl_file.write_text(
+        json.dumps({"type": "sync", "query": ["https://open.spotify.com/playlist/x"], "songs": songs}),
+        encoding="utf-8",
+    )
+    return spotdl_file
+
+
+def _make_library_paths(base: Path, count: int) -> list[Path]:
+    staging = base / "staging"
+    staging.mkdir(exist_ok=True)
+    paths = [staging / f"track_{i}.m4a" for i in range(count)]
+    for p in paths:
+        p.touch()
+    return paths
+
+
+def _mock_library(paths: list[Path]) -> mock.Mock:
+    lib = mock.Mock()
+    lib.paths_by_source.return_value = paths
+    return lib
+
+
+# ---------------------------------------------------------------------------
+# reconcile_snapshot — all URLs present in library
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_all_present_no_changes(tmp_path: Path) -> None:
+    """When every snapshot URL has a matching file in the library, nothing is dropped."""
+    urls = [
+        "https://open.spotify.com/track/A",
+        "https://open.spotify.com/track/B",
+        "https://open.spotify.com/track/C",
+    ]
+    spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
+    lib_paths = _make_library_paths(tmp_path, len(urls))
+    lib = _mock_library(lib_paths)
+
+    with mock.patch("music_scan.reconcile._read_spotify_url", side_effect=urls):
+        dropped = reconcile_snapshot(spotdl_file, lib)
+
+    assert dropped == 0
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    assert {s["url"] for s in data["songs"]} == set(urls)
+
+
+# ---------------------------------------------------------------------------
+# reconcile_snapshot — one URL missing from library
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_one_missing_dropped(tmp_path: Path) -> None:
+    """A URL absent from both library and quarantine is dropped and logged."""
+    urls = [
+        "https://open.spotify.com/track/A",
+        "https://open.spotify.com/track/B",
+        "https://open.spotify.com/track/C",
+    ]
+    spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
+    # Library only has A and B
+    lib_paths = _make_library_paths(tmp_path, 2)
+    lib = _mock_library(lib_paths)
+
+    with mock.patch(
+        "music_scan.reconcile._read_spotify_url",
+        side_effect=["https://open.spotify.com/track/A", "https://open.spotify.com/track/B"],
+    ):
+        dropped = reconcile_snapshot(spotdl_file, lib)
+
+    assert dropped == 1
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    persisted = {s["url"] for s in data["songs"]}
+    assert persisted == {"https://open.spotify.com/track/A", "https://open.spotify.com/track/B"}
+    assert "https://open.spotify.com/track/C" not in persisted
+
+
+def test_reconcile_one_missing_logs_warning(tmp_path: Path, caplog) -> None:
+    """A WARNING is emitted for each dropped URL."""
+    import logging
+
+    urls = ["https://open.spotify.com/track/A", "https://open.spotify.com/track/B"]
+    spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
+    lib = _mock_library(_make_library_paths(tmp_path, 1))
+
+    with mock.patch(
+        "music_scan.reconcile._read_spotify_url",
+        side_effect=["https://open.spotify.com/track/A"],
+    ):
+        with caplog.at_level(logging.WARNING, logger="music_scan.reconcile"):
+            reconcile_snapshot(spotdl_file, lib)
+
+    assert any("https://open.spotify.com/track/B" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# reconcile_snapshot — all URLs missing from library
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_all_missing_drops_all(tmp_path: Path) -> None:
+    """When no URLs are in the library or quarantine, all are dropped."""
+    urls = ["https://open.spotify.com/track/A", "https://open.spotify.com/track/B"]
+    spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
+    lib = _mock_library([])
+
+    dropped = reconcile_snapshot(spotdl_file, lib)
+
+    assert dropped == 2
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    assert data["songs"] == []
+
+
+# ---------------------------------------------------------------------------
+# reconcile_snapshot — quarantine keeps URLs alive
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_quarantined_url_not_dropped(tmp_path: Path) -> None:
+    """A URL whose file is in quarantine is retained (not re-downloaded)."""
+    url_a = "https://open.spotify.com/track/A"
+    url_b = "https://open.spotify.com/track/B"
+    spotdl_file = _write_snapshot(tmp_path, "mypl", [url_a, url_b])
+
+    lib_paths = _make_library_paths(tmp_path, 1)
+    lib = _mock_library(lib_paths)
+
+    # A is in the library; B is in quarantine (passed as safe_urls)
+    with mock.patch("music_scan.reconcile._read_spotify_url", return_value=url_a):
+        dropped = reconcile_snapshot(spotdl_file, lib, safe_urls={url_b})
+
+    assert dropped == 0
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    assert {s["url"] for s in data["songs"]} == {url_a, url_b}
+
+
+# ---------------------------------------------------------------------------
+# reconcile_snapshot — stale beets paths handled gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_stale_library_path_treated_as_missing(tmp_path: Path) -> None:
+    """A beets library entry whose file no longer exists is not counted as verified."""
+    url = "https://open.spotify.com/track/A"
+    spotdl_file = _write_snapshot(tmp_path, "mypl", [url])
+
+    # Library returns a path that does not exist on disk
+    ghost_path = tmp_path / "staging" / "ghost.m4a"
+    lib = _mock_library([ghost_path])
+
+    dropped = reconcile_snapshot(spotdl_file, lib)
+
+    assert dropped == 1
+    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
+    assert data["songs"] == []
+
+
+# ---------------------------------------------------------------------------
+# reconcile_snapshot — empty snapshot is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_empty_snapshot_no_op(tmp_path: Path) -> None:
+    spotdl_file = tmp_path / "mypl.spotdl"
+    spotdl_file.write_text(
+        json.dumps({"type": "sync", "query": ["https://..."], "songs": []}),
+        encoding="utf-8",
+    )
+    lib = _mock_library([])
+
+    dropped = reconcile_snapshot(spotdl_file, lib)
+
+    assert dropped == 0
+    lib.paths_by_source.assert_not_called()

--- a/service/music_service/orchestrator.py
+++ b/service/music_service/orchestrator.py
@@ -14,6 +14,7 @@ from watchdog.events import FileCreatedEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 import music_fetch.ingest as ingest
+import music_scan.reconcile as reconcile
 import music_scan.scan as scan
 from music_scan.navidrome import trigger_scan
 
@@ -63,6 +64,8 @@ class Orchestrator:
         """Run scan — caller must already hold self._lock."""
         logger.info("==> Scan starting")
         scan.run(pending)
+        logger.info("==> Reconciling snapshots against library")
+        reconcile.reconcile_all()
         pushed = self._push_library()
         if pushed:
             trigger_scan()

--- a/service/tests/test_orchestrator.py
+++ b/service/tests/test_orchestrator.py
@@ -67,7 +67,8 @@ def test_run_fetch_calls_ingest_then_scan_with_pending():
     mock_pending = MagicMock()
 
     with patch("music_service.orchestrator.ingest") as mock_ingest, \
-         patch("music_service.orchestrator.scan") as mock_scan:
+         patch("music_service.orchestrator.scan") as mock_scan, \
+         patch("music_service.orchestrator.reconcile"):
         mock_ingest.run.return_value = mock_pending
         orc.run_fetch()
         mock_ingest.run.assert_called_once()
@@ -78,14 +79,16 @@ def test_run_scan_calls_scan_run():
     orc = Orchestrator(debounce_delay=30.0)
     mock_pending = MagicMock()
 
-    with patch("music_service.orchestrator.scan") as mock_scan:
+    with patch("music_service.orchestrator.scan") as mock_scan, \
+         patch("music_service.orchestrator.reconcile"):
         orc.run_scan(mock_pending)
         mock_scan.run.assert_called_once_with(mock_pending)
 
 
 def test_run_scan_no_pending():
     orc = Orchestrator(debounce_delay=30.0)
-    with patch("music_service.orchestrator.scan") as mock_scan:
+    with patch("music_service.orchestrator.scan") as mock_scan, \
+         patch("music_service.orchestrator.reconcile"):
         orc.run_scan()
         mock_scan.run.assert_called_once_with(None)
 
@@ -198,18 +201,20 @@ def test_push_library_uses_default_paths_when_env_unset(monkeypatch):
 
 
 def test_run_scan_locked_calls_scan_then_push_then_trigger_in_order(monkeypatch):
-    """scan.run → _push_library → trigger_scan must execute in that order when push succeeds."""
+    """scan.run → reconcile → _push_library → trigger_scan must execute in that order."""
     call_order: list[str] = []
 
     orc = Orchestrator()
 
     with patch("music_service.orchestrator.scan") as mock_scan, \
+         patch("music_service.orchestrator.reconcile") as mock_reconcile, \
          patch.object(orc, "_push_library", return_value=True, side_effect=lambda: call_order.append("push") or True), \
          patch("music_service.orchestrator.trigger_scan", side_effect=lambda: call_order.append("trigger")):
         mock_scan.run.side_effect = lambda pending=None: call_order.append("scan")
+        mock_reconcile.reconcile_all.side_effect = lambda: call_order.append("reconcile")
         orc._run_scan_locked()
 
-    assert call_order == ["scan", "push", "trigger"]
+    assert call_order == ["scan", "reconcile", "push", "trigger"]
 
 
 def test_run_scan_locked_always_triggers_scan_regardless_of_remote(monkeypatch):
@@ -220,10 +225,12 @@ def test_run_scan_locked_always_triggers_scan_regardless_of_remote(monkeypatch):
     orc = Orchestrator()
 
     with patch("music_service.orchestrator.scan") as mock_scan, \
+         patch("music_service.orchestrator.reconcile") as mock_reconcile, \
          patch.object(orc, "_push_library", return_value=False, side_effect=lambda: call_order.append("push") or False), \
          patch("music_service.orchestrator.trigger_scan", side_effect=lambda: call_order.append("trigger")):
         mock_scan.run.side_effect = lambda pending=None: call_order.append("scan")
+        mock_reconcile.reconcile_all.side_effect = lambda: call_order.append("reconcile")
         orc._run_scan_locked()
 
     # trigger_scan is skipped when nothing was pushed
-    assert call_order == ["scan", "push"]
+    assert call_order == ["scan", "reconcile", "push"]


### PR DESCRIPTION
## Summary

- Adds `scan/music_scan/reconcile.py` with `reconcile_snapshot()` and `reconcile_all()` — diffs each `.spotdl` snapshot against the beets library by reading the `----:spotdl:WOAS` Spotify URL tag spotdl embeds in every M4A file
- Orchestrator calls `reconcile.reconcile_all()` after each scan, before the library push
- Drops snapshot URLs absent from both the beets library and the quarantine directory, logging a `WARNING` per URL; quarantined tracks are preserved to avoid re-download loops
- Adds 6 unit tests covering: all present, one missing, all missing, quarantine retention, stale beets path, empty snapshot no-op

## Why this approach

The suggested fix in #81 (check `output_dir` for file existence) is incorrect for this codebase: beets uses `move: yes`, so inbox files are absent from `output_dir` after every successful scan. Checking `output_dir` would incorrectly trigger re-downloads on every normal run.

The orchestrator-side reconcile approach verifies against the actual beets library — the ground truth — and only drops URLs that are genuinely missing from both the library and quarantine.

## Test plan

- [ ] `just test` passes (all 3 image suites, including new reconcile unit tests)
- [ ] After a real run: no WARNING logs appear when all tracks are in the library
- [ ] After manually removing a URL from the library: WARNING appears for that URL on the next scan, URL is dropped from snapshot, re-downloaded on subsequent fetch

Closes #81