### PR TITLE
fix: push failure sets last_run_success=0 (#84)

### DIFF
--- a/scan/music_scan/navidrome.py
+++ b/scan/music_scan/navidrome.py
@@ -25,8 +25,9 @@ def trigger_scan() -> None:
         return
 
     if not user or not password:
-        logger.warning("NAVIDROME_URL is set but NAVIDROME_USER or NAVIDROME_PASSWORD is missing — skipping rescan")
-        return
+        raise RuntimeError(
+            "NAVIDROME_URL is set but NAVIDROME_USER or NAVIDROME_PASSWORD is missing"
+        )
 
     endpoint = f"{url.rstrip('/')}/rest/startScan.view"
     params = {
@@ -39,11 +40,10 @@ def trigger_scan() -> None:
     try:
         resp = requests.get(endpoint, params=params, timeout=10)
         resp.raise_for_status()
-        data = resp.json()
-        status = data.get("subsonic-response", {}).get("status")
-        if status != "ok":
-            logger.warning("Navidrome rescan returned non-ok status: %s", data)
-        else:
-            logger.info("==> Navidrome library rescan triggered")
     except requests.RequestException as exc:
-        logger.warning("Failed to trigger Navidrome rescan: %s", exc)
+        raise RuntimeError(f"Failed to trigger Navidrome rescan: {exc}") from exc
+    data = resp.json()
+    status = data.get("subsonic-response", {}).get("status")
+    if status != "ok":
+        raise RuntimeError(f"Navidrome rescan returned non-ok status: {data}")
+    logger.info("==> Navidrome library rescan triggered")

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from music_fetch.ingest import PendingRemovals
 from music_scan.library import MusicLibrary
 from music_scan.metrics import ScanMetrics
+from music_scan.navidrome import trigger_scan
 from music_scan.process import run_beet_import, run_beet_update
 
 logger = logging.getLogger(__name__)
@@ -246,13 +247,21 @@ def run(pending: PendingRemovals | None = None) -> None:
         quarantined_after = _count_quarantine()
         metrics.quarantined_tracks = max(0, quarantined_after - quarantined_before)
 
-        logger.info("==> music-scan complete")
+        logger.info("==> music-scan import complete")
 
     except Exception:
         metrics.success = False
         metrics.failure_reason = "unexpected_error"
         logger.exception("music-scan failed")
         raise
+    else:
+        try:
+            trigger_scan()
+        except Exception as exc:
+            metrics.success = False
+            metrics.failure_reason = "navidrome_trigger_failed"
+            logger.error("Navidrome rescan trigger failed — tracks may not appear in Navidrome: %s", exc)
+            raise
     finally:
         metrics.duration_seconds = int(time.monotonic() - start)
         metrics.push()

--- a/scan/tests/test_navidrome.py
+++ b/scan/tests/test_navidrome.py
@@ -28,33 +28,29 @@ def test_no_url_skips_http_call():
     mock_get.assert_not_called()
 
 
-def test_url_without_credentials_logs_warning(monkeypatch, caplog):
-    """When URL is set but credentials are missing, log a warning and skip."""
+def test_url_without_credentials_raises(monkeypatch):
+    """When URL is set but credentials are missing, RuntimeError is raised."""
     monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
 
     with mock.patch("music_scan.navidrome.requests.get") as mock_get:
-        import logging
-        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
-            from music_scan.navidrome import trigger_scan
+        from music_scan.navidrome import trigger_scan
+        with pytest.raises(RuntimeError, match="NAVIDROME_USER or NAVIDROME_PASSWORD is missing"):
             trigger_scan()
 
     mock_get.assert_not_called()
-    assert "NAVIDROME_USER or NAVIDROME_PASSWORD is missing" in caplog.text
 
 
-def test_url_with_only_user_logs_warning(monkeypatch, caplog):
-    """When URL and user are set but password is missing, still warns."""
+def test_url_with_only_user_raises(monkeypatch):
+    """When URL and user are set but password is missing, RuntimeError is raised."""
     monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
     monkeypatch.setenv("NAVIDROME_USER", "admin")
 
     with mock.patch("music_scan.navidrome.requests.get") as mock_get:
-        import logging
-        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
-            from music_scan.navidrome import trigger_scan
+        from music_scan.navidrome import trigger_scan
+        with pytest.raises(RuntimeError, match="NAVIDROME_USER or NAVIDROME_PASSWORD is missing"):
             trigger_scan()
 
     mock_get.assert_not_called()
-    assert "NAVIDROME_USER or NAVIDROME_PASSWORD is missing" in caplog.text
 
 
 def test_successful_scan_logs_info(monkeypatch, caplog):
@@ -97,8 +93,8 @@ def test_trailing_slash_in_url_is_normalized(monkeypatch):
     assert "//" not in url_called.replace("http://", "")
 
 
-def test_non_ok_subsonic_status_logs_warning(monkeypatch, caplog):
-    """When Subsonic returns a non-ok status, a warning is logged."""
+def test_non_ok_subsonic_status_raises(monkeypatch):
+    """When Subsonic returns a non-ok status, RuntimeError is raised."""
     monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
     monkeypatch.setenv("NAVIDROME_USER", "admin")
     monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
@@ -107,16 +103,13 @@ def test_non_ok_subsonic_status_logs_warning(monkeypatch, caplog):
     mock_resp.json.return_value = _make_subsonic_response("failed")
 
     with mock.patch("music_scan.navidrome.requests.get", return_value=mock_resp):
-        import logging
-        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
-            from music_scan.navidrome import trigger_scan
+        from music_scan.navidrome import trigger_scan
+        with pytest.raises(RuntimeError, match="non-ok status"):
             trigger_scan()
 
-    assert "non-ok status" in caplog.text
 
-
-def test_http_error_logs_warning(monkeypatch, caplog):
-    """When requests raises a RequestException, a warning is logged (not raised)."""
+def test_http_error_raises(monkeypatch):
+    """When requests raises a RequestException, RuntimeError is raised."""
     monkeypatch.setenv("NAVIDROME_URL", "http://navidrome.example.com")
     monkeypatch.setenv("NAVIDROME_USER", "admin")
     monkeypatch.setenv("NAVIDROME_PASSWORD", "secret")
@@ -125,9 +118,6 @@ def test_http_error_logs_warning(monkeypatch, caplog):
         "music_scan.navidrome.requests.get",
         side_effect=requests.ConnectionError("connection refused"),
     ):
-        import logging
-        with caplog.at_level(logging.WARNING, logger="music_scan.navidrome"):
-            from music_scan.navidrome import trigger_scan
+        from music_scan.navidrome import trigger_scan
+        with pytest.raises(RuntimeError, match="Failed to trigger Navidrome rescan"):
             trigger_scan()
-
-    assert "Failed to trigger Navidrome rescan" in caplog.text

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -160,6 +160,43 @@ def test_apply_pending_removals_returns_total_count() -> None:
     assert count == 3
 
 
+def test_run_trigger_scan_failure_sets_success_false(tmp_path: Path) -> None:
+    """When trigger_scan raises, last_run_success=0 is pushed and the exception propagates."""
+    from music_scan import scan
+
+    captured: list = []
+
+    class FakeMetrics:
+        def __init__(self):
+            self.success = True
+            self.failure_reason = ""
+            self.tracks_imported = 0
+            self.tracks_removed = 0
+            self.quarantined_tracks = 0
+            self.duration_seconds = 0
+            captured.append(self)
+
+        def push(self):
+            pass
+
+    with mock.patch("music_scan.scan.MusicLibrary", return_value=_make_mock_lib()), \
+         mock.patch("music_scan.scan.run_beet_import"), \
+         mock.patch("music_scan.scan.run_beet_update"), \
+         mock.patch("music_scan.scan._move_asis_eligible", return_value=0), \
+         mock.patch("music_scan.scan.INBOX", tmp_path), \
+         mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
+         mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.ScanMetrics", FakeMetrics), \
+         mock.patch("music_scan.scan.trigger_scan", side_effect=RuntimeError("connection refused")):
+        with pytest.raises(RuntimeError, match="connection refused"):
+            scan.run(pending=None)
+
+    assert len(captured) == 1
+    assert captured[0].success is False
+    assert captured[0].failure_reason == "navidrome_trigger_failed"
+
+
 def test_run_with_pending_none_skips_apply(tmp_path: Path) -> None:
     """run(pending=None) never calls _apply_pending_removals."""
     from music_scan import scan

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -22,8 +22,8 @@ def test_smoke_empty_inbox(docker_client, volumes):
     """Scan against empty volumes exits 0 and reaches the completion log line."""
     exit_code, logs = run_scan(docker_client, volumes)
     assert exit_code == 0, f"music-scan exited {exit_code}. Logs:\n{logs}"
-    assert "music-scan complete" in logs, (
-        "Expected 'music-scan complete' in logs. Logs:\n" + logs
+    assert "music-scan import complete" in logs, (
+        "Expected 'music-scan import complete' in logs. Logs:\n" + logs
     )
 
 


### PR DESCRIPTION
## Summary

- `trigger_scan()` was silently swallowing all Navidrome rescan errors as `logger.warning`, so push failures never showed up in metrics or fired `MusicIngestFailed`
- `trigger_scan()` was also not called at all in `music_scan/scan.py` (dropped during the migration from the old `pipeline/` package)
- `trigger_scan()` now raises `RuntimeError` on missing credentials, HTTP failure, or non-ok Subsonic status
- `scan.run()` calls `trigger_scan()` in a `try/else/finally` structure so import failures and Navidrome trigger failures produce distinct `failure_reason` values (`unexpected_error` vs `navidrome_trigger_failed`) while `last_run_success=0` is guaranteed to be pushed in both cases via `finally`
- Log message updated to `"music-scan import complete"` to distinguish the import step from the trigger step

## Test plan

- [ ] All 71 scan unit tests pass (`PYTHONPATH=fetch .venv/bin/pytest scan/tests/ -v`)
- [ ] `test_run_trigger_scan_failure_sets_success_false` — new test: `trigger_scan` raises → `success=False`, `failure_reason="navidrome_trigger_failed"`, `push()` called
- [ ] Updated navidrome tests: `test_url_without_credentials_raises`, `test_url_with_only_user_raises`, `test_non_ok_subsonic_status_raises`, `test_http_error_raises`

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)