### PR TITLE
fix: guard against empty staging dir before beet update

### DIFF
--- a/scan/music_scan/library.py
+++ b/scan/music_scan/library.py
@@ -36,6 +36,10 @@ class MusicLibrary:
         """All items whose source flexible-attribute matches *source*."""
         return list(self._lib.items(f"source:{source}"))
 
+    def item_count(self) -> int:
+        """Return the total number of items in the library."""
+        return sum(1 for _ in self._lib.items())
+
     def items_added_since(self, since: float) -> list[tuple[str, str]]:
         """Return (title, artist) for items added to the library after *since* (Unix timestamp)."""
         return [

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -29,6 +29,7 @@ QUARANTINE = Path("/root/Music/quarantine")
 PLAYLISTS = Path("/root/Music/playlists")
 INBOX = Path("/root/Music/inbox")
 LIBRARY_DB = Path("/root/.config/beets/library.db")
+LIBRARY_DIR = Path("/root/Music/staging")
 
 
 _STOP_WORDS = frozenset({"the", "and", "for", "feat", "ft", "vs", "with", "a", "an", "of", "in", "on"})
@@ -78,6 +79,12 @@ def _check_import_names(inbox_stems: list[str], imported: list[tuple[str, str]])
             logger.warning("  !! %s — %s  (best inbox overlap: %.0f%%)", title, artist, score * 100)
     else:
         logger.info("==> Name check OK: all %d imported tracks resemble their inbox source files", len(imported))
+
+
+def _count_library_audio(library_dir: Path) -> int:
+    if not library_dir.is_dir():
+        return 0
+    return sum(1 for f in library_dir.rglob("*") if f.is_file() and f.suffix.lower() in AUDIO_EXTS)
 
 
 def _count_quarantine() -> int:
@@ -239,7 +246,19 @@ def run(pending: PendingRemovals | None = None) -> None:
         metrics.tracks_imported = len(imported) + len(asis_imported)
 
         logger.info("==> Refreshing library metadata...")
-        run_beet_update()
+        lib_audio_count = _count_library_audio(LIBRARY_DIR)
+        with MusicLibrary(LIBRARY_DB) as lib:
+            db_item_count = lib.item_count()
+        if lib_audio_count == 0 and db_item_count > 0:
+            logger.error(
+                "staging appears empty but library has %d items — skipping beet update to prevent DB corruption"
+                " (staging_files=%d, library_items=%d)",
+                db_item_count, lib_audio_count, db_item_count,
+            )
+            metrics.success = False
+            metrics.failure_reason = "empty_library_dir"
+        else:
+            run_beet_update()
 
         logger.info("==> Regenerating playlists...")
         _regen_playlists()

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -188,6 +188,7 @@ def test_run_trigger_scan_failure_sets_success_false(tmp_path: Path) -> None:
          mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
          mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
          mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.LIBRARY_DIR", tmp_path), \
          mock.patch("music_scan.scan.ScanMetrics", FakeMetrics), \
          mock.patch("music_scan.scan.trigger_scan", side_effect=RuntimeError("connection refused")):
         with pytest.raises(RuntimeError, match="connection refused"):
@@ -211,6 +212,7 @@ def test_run_with_pending_none_skips_apply(tmp_path: Path) -> None:
          mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
          mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
          mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.LIBRARY_DIR", tmp_path), \
          mock.patch("music_scan.scan.ScanMetrics"):
         scan.run(pending=None)
 

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -96,6 +96,7 @@ def _make_mock_lib() -> mock.MagicMock:
     mock_lib.items_by_source = mock.MagicMock(return_value=[])
     mock_lib.items_added_since = mock.MagicMock(return_value=[])
     mock_lib.paths_by_source = mock.MagicMock(return_value=[])
+    mock_lib.item_count = mock.MagicMock(return_value=0)
     return mock_lib
 
 
@@ -427,3 +428,86 @@ def test_run_beet_import_no_asis_flag_by_default() -> None:
     assert "--quiet" in cmd
 
 
+# ---------------------------------------------------------------------------
+# beet update guard: empty library dir
+# ---------------------------------------------------------------------------
+
+def _run_with_patches(tmp_path: Path, library_dir: Path, mock_lib: mock.MagicMock) -> tuple:
+    """Run scan.run(pending=None) with standard patches and return (captured_metrics, mock_update)."""
+    from music_scan import scan
+
+    captured: list = []
+
+    class FakeMetrics:
+        def __init__(self):
+            self.success = True
+            self.failure_reason = ""
+            self.tracks_imported = 0
+            self.tracks_removed = 0
+            self.quarantined_tracks = 0
+            self.duration_seconds = 0
+            captured.append(self)
+
+        def push(self):
+            pass
+
+    mock_update = mock.MagicMock()
+
+    with mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib), \
+         mock.patch("music_scan.scan.run_beet_import"), \
+         mock.patch("music_scan.scan.run_beet_update", mock_update), \
+         mock.patch("music_scan.scan._move_asis_eligible", return_value=0), \
+         mock.patch("music_scan.scan.INBOX", tmp_path), \
+         mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
+         mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.LIBRARY_DIR", library_dir), \
+         mock.patch("music_scan.scan.ScanMetrics", FakeMetrics), \
+         mock.patch("music_scan.scan.trigger_scan"):
+        scan.run(pending=None)
+
+    return captured, mock_update
+
+
+def test_beet_update_skipped_when_staging_empty_and_db_nonempty(tmp_path: Path) -> None:
+    """Guard fires: staging dir has no audio files but DB has items — beet update is skipped."""
+    mock_lib = _make_mock_lib()
+    mock_lib.item_count = mock.MagicMock(return_value=42)
+
+    # library_dir = tmp_path has no audio files
+    captured, mock_update = _run_with_patches(tmp_path, tmp_path, mock_lib)
+
+    assert len(captured) == 1
+    assert captured[0].success is False
+    assert captured[0].failure_reason == "empty_library_dir"
+    mock_update.assert_not_called()
+
+
+def test_beet_update_runs_when_staging_has_audio(tmp_path: Path) -> None:
+    """Normal operation: staging has at least one audio file — beet update runs."""
+    library_dir = tmp_path / "staging"
+    library_dir.mkdir()
+    (library_dir / "Artist" / "Album").mkdir(parents=True)
+    (library_dir / "Artist" / "Album" / "01 - Track.m4a").touch()
+
+    mock_lib = _make_mock_lib()
+    mock_lib.item_count = mock.MagicMock(return_value=42)
+
+    captured, mock_update = _run_with_patches(tmp_path, library_dir, mock_lib)
+
+    assert len(captured) == 1
+    assert captured[0].success is True
+    mock_update.assert_called_once()
+
+
+def test_beet_update_runs_on_first_run_with_empty_staging_and_empty_db(tmp_path: Path) -> None:
+    """First run: staging is empty and DB is empty — nothing to protect, beet update runs."""
+    mock_lib = _make_mock_lib()
+    mock_lib.item_count = mock.MagicMock(return_value=0)
+
+    # library_dir = tmp_path has no audio files; DB also has 0 items
+    captured, mock_update = _run_with_patches(tmp_path, tmp_path, mock_lib)
+
+    assert len(captured) == 1
+    assert captured[0].success is True
+    mock_update.assert_called_once()


### PR DESCRIPTION
Closes #83.

## Summary
- Before calling `beet update`, counts audio files in `/root/Music/staging` (the beets library dir) and items in the DB
- If staging has 0 audio files **and** DB has > 0 items, skips `beet update`, logs a structured error with both counts, and sets `last_run_success=0`
- First-run state (empty staging + empty DB) is allowed through unchanged
- Adds `MusicLibrary.item_count()` helper used by the guard

## Test plan
- [ ] `test_beet_update_skipped_when_staging_empty_and_db_nonempty` — guard fires, `run_beet_update` not called, `failure_reason="empty_library_dir"`
- [ ] `test_beet_update_runs_when_staging_has_audio` — normal operation, `run_beet_update` called once
- [ ] `test_beet_update_runs_on_first_run_with_empty_staging_and_empty_db` — first-run, `run_beet_update` called once
- [ ] All existing tests pass (updated `_make_mock_lib` to include `item_count=0` so existing tests are unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)