### PR TITLE
refactor: promote ingest and scan sub-steps to explicit orchestrator steps

### DIFF
--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -96,7 +96,7 @@ def _jitter() -> None:
         time.sleep(delay)
 
 
-def _reconcile_playlists() -> list[str]:
+def reconcile_playlists() -> list[str]:
     """Reconcile disk state with playlists.conf; return list of removed source names.
 
     - Provisions new playlist entries (spotdl save for entries without .spotdl).
@@ -180,6 +180,130 @@ def _collect_removals(
         pending.append(RemovedTrack(title=title, artist=artist, source=playlist_name))
 
 
+def sync_playlists(
+    remove_sources: list[str],
+    metrics: IngestMetrics,
+    start: float | None = None,
+) -> PendingRemovals:
+    """Run the spotdl download loop for all active playlists. Returns pending removals.
+
+    *start* is the monotonic time the overall run began, used for soft-timeout
+    accounting.  Defaults to now if not provided (standalone use).
+    """
+    if start is None:
+        start = time.monotonic()
+
+    track_limit_str = os.environ.get("SYNC_TRACK_LIMIT", "")
+    session_budget: int | None = None
+    if track_limit_str.strip():
+        try:
+            session_budget = int(track_limit_str.strip())
+        except ValueError:
+            logger.error("SYNC_TRACK_LIMIT must be a positive integer, got %r — ignoring", track_limit_str)
+    if session_budget is not None and session_budget <= 0:
+        logger.error("SYNC_TRACK_LIMIT must be a positive integer, got %d — ignoring", session_budget)
+        session_budget = None
+    remaining: int | None = session_budget
+
+    if session_budget is not None:
+        logger.info("Session track budget: %d new tracks across all playlists", session_budget)
+
+    timeout_str = os.environ.get("SYNC_TIMEOUT_SECONDS", "")
+    soft_timeout: int | None = None
+    if timeout_str.strip():
+        try:
+            soft_timeout = int(timeout_str.strip())
+        except ValueError:
+            logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %r — ignoring", timeout_str)
+    if soft_timeout is not None and soft_timeout <= 0:
+        logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %d — ignoring", soft_timeout)
+        soft_timeout = None
+
+    if soft_timeout is not None:
+        logger.info("Soft timeout: %ds — will stop before Kubernetes deadline fires", soft_timeout)
+
+    spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
+    if not spotdl_files:
+        logger.info("No .spotdl files found in %s", SPOTDL_DIR)
+
+    pending_removals: list[RemovedTrack] = []
+
+    for spotdl_file in spotdl_files:
+        name = spotdl_file.stem
+
+        # .nosync: skip spotdl sync for frozen playlists
+        if (SPOTDL_DIR / f"{name}.nosync").exists():
+            logger.info("==> Skipping sync for static playlist: %s (.nosync present)", name)
+            metrics.playlists_skipped += 1
+            metrics.playlists_total += 1
+            continue
+
+        # Budget exhausted: defer remaining playlists to the next session.
+        if remaining is not None and remaining <= 0:
+            logger.info("==> Track budget exhausted — deferring %s to next session", name)
+            metrics.playlists_deferred += 1
+            metrics.playlists_total += 1
+            continue
+
+        # Soft timeout: stop before the Kubernetes activeDeadlineSeconds fires.
+        if _deadline_reached(time.monotonic() - start, soft_timeout):
+            logger.info(
+                "==> Soft timeout reached (%ds/%ds) — deferring %s to next session",
+                int(time.monotonic() - start),
+                soft_timeout,
+                name,
+            )
+            metrics.playlists_deferred += 1
+            metrics.playlists_total += 1
+            continue
+
+        # Validate JSON before we attempt a sync
+        try:
+            with open(spotdl_file, encoding="utf-8") as fh:
+                sync_data = json.load(fh)
+        except json.JSONDecodeError:
+            logger.warning("WARNING: %s is not valid JSON — skipping", spotdl_file)
+            metrics.playlists_total += 1
+            continue
+
+        old_songs: list[dict] = sync_data if isinstance(sync_data, list) else []
+
+        logger.info("==> Syncing playlist: %s", name)
+        metrics.playlists_total += 1
+        output_dir = SPOTDL_DIR / name
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            removed_urls, tracks_sent = sync_playlist(
+                spotdl_file=spotdl_file,
+                output_dir=output_dir,
+                cookie_file=COOKIE_FILE,
+                track_limit=remaining,
+            )
+        except Exception as exc:
+            reason = classify_failure(str(exc))
+            logger.error(
+                "ERROR: spotdl sync failed for %s (reason=%s): %s", name, reason, exc
+            )
+            metrics.success = False
+            metrics.failure_reason = reason
+            if reason == "auth_youtube":
+                metrics.cookies_expired = True
+            raise
+
+        metrics.tracks_downloaded += tracks_sent
+        if remaining is not None:
+            remaining -= tracks_sent
+
+        _collect_removals(pending_removals, removed_urls, old_songs, name)
+
+        # Brief pause between playlists — avoid hammering Spotify/YouTube APIs.
+        time.sleep(5)
+
+    logger.info("==> music-ingest complete. Run music-scan for local import and playlist generation.")
+    return PendingRemovals(tracks=pending_removals, remove_sources=remove_sources)
+
+
 def run() -> PendingRemovals:
     """Execute the full ingest pipeline, push metrics on completion, return pending removals."""
     metrics = IngestMetrics()
@@ -198,117 +322,17 @@ def run() -> PendingRemovals:
     try:
         logger.info("==> music-ingest starting")
 
-        remove_sources = _reconcile_playlists()
+        logger.info("==> Reconciling playlists...")
+        try:
+            remove_sources = reconcile_playlists()
+        except Exception:
+            metrics.success = False
+            metrics.failure_reason = "reconcile_error"
+            logger.exception("Reconciliation step failed")
+            raise
 
-        track_limit_str = os.environ.get("SYNC_TRACK_LIMIT", "")
-        session_budget: int | None = None
-        if track_limit_str.strip():
-            try:
-                session_budget = int(track_limit_str.strip())
-            except ValueError:
-                logger.error("SYNC_TRACK_LIMIT must be a positive integer, got %r — ignoring", track_limit_str)
-        if session_budget is not None and session_budget <= 0:
-            logger.error("SYNC_TRACK_LIMIT must be a positive integer, got %d — ignoring", session_budget)
-            session_budget = None
-        remaining: int | None = session_budget
-
-        if session_budget is not None:
-            logger.info("Session track budget: %d new tracks across all playlists", session_budget)
-
-        timeout_str = os.environ.get("SYNC_TIMEOUT_SECONDS", "")
-        soft_timeout: int | None = None
-        if timeout_str.strip():
-            try:
-                soft_timeout = int(timeout_str.strip())
-            except ValueError:
-                logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %r — ignoring", timeout_str)
-        if soft_timeout is not None and soft_timeout <= 0:
-            logger.error("SYNC_TIMEOUT_SECONDS must be a positive integer, got %d — ignoring", soft_timeout)
-            soft_timeout = None
-
-        if soft_timeout is not None:
-            logger.info("Soft timeout: %ds — will stop before Kubernetes deadline fires", soft_timeout)
-
-        spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
-        if not spotdl_files:
-            logger.info("No .spotdl files found in %s", SPOTDL_DIR)
-
-        pending_removals: list[RemovedTrack] = []
-
-        for spotdl_file in spotdl_files:
-            name = spotdl_file.stem
-
-            # .nosync: skip spotdl sync for frozen playlists
-            if (SPOTDL_DIR / f"{name}.nosync").exists():
-                logger.info("==> Skipping sync for static playlist: %s (.nosync present)", name)
-                metrics.playlists_skipped += 1
-                metrics.playlists_total += 1
-                continue
-
-            # Budget exhausted: defer remaining playlists to the next session.
-            if remaining is not None and remaining <= 0:
-                logger.info("==> Track budget exhausted — deferring %s to next session", name)
-                metrics.playlists_deferred += 1
-                metrics.playlists_total += 1
-                continue
-
-            # Soft timeout: stop before the Kubernetes activeDeadlineSeconds fires.
-            if _deadline_reached(time.monotonic() - start, soft_timeout):
-                logger.info(
-                    "==> Soft timeout reached (%ds/%ds) — deferring %s to next session",
-                    int(time.monotonic() - start),
-                    soft_timeout,
-                    name,
-                )
-                metrics.playlists_deferred += 1
-                metrics.playlists_total += 1
-                continue
-
-            # Validate JSON before we attempt a sync
-            try:
-                with open(spotdl_file, encoding="utf-8") as fh:
-                    sync_data = json.load(fh)
-            except json.JSONDecodeError:
-                logger.warning("WARNING: %s is not valid JSON — skipping", spotdl_file)
-                metrics.playlists_total += 1
-                continue
-
-            old_songs: list[dict] = sync_data if isinstance(sync_data, list) else []
-
-            logger.info("==> Syncing playlist: %s", name)
-            metrics.playlists_total += 1
-            output_dir = SPOTDL_DIR / name
-            output_dir.mkdir(parents=True, exist_ok=True)
-
-            try:
-                removed_urls, tracks_sent = sync_playlist(
-                    spotdl_file=spotdl_file,
-                    output_dir=output_dir,
-                    cookie_file=COOKIE_FILE,
-                    track_limit=remaining,
-                )
-            except Exception as exc:
-                reason = classify_failure(str(exc))
-                logger.error(
-                    "ERROR: spotdl sync failed for %s (reason=%s): %s", name, reason, exc
-                )
-                metrics.success = False
-                metrics.failure_reason = reason
-                if reason == "auth_youtube":
-                    metrics.cookies_expired = True
-                raise
-
-            metrics.tracks_downloaded += tracks_sent
-            if remaining is not None:
-                remaining -= tracks_sent
-
-            _collect_removals(pending_removals, removed_urls, old_songs, name)
-
-            # Brief pause between playlists — avoid hammering Spotify/YouTube APIs.
-            time.sleep(5)
-
-        logger.info("==> music-ingest complete. Run music-scan for local import and playlist generation.")
-        return PendingRemovals(tracks=pending_removals, remove_sources=remove_sources)
+        logger.info("==> Syncing playlists...")
+        return sync_playlists(remove_sources, metrics, start=start)
 
     except SystemExit:
         raise

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, _reconcile_playlists, PendingRemovals, RemovedTrack
+from music_fetch.ingest import classify_failure, _collect_removals, _deadline_reached, reconcile_playlists, PendingRemovals, RemovedTrack
 from music_fetch.spotdl_ops import find_track_in_snapshot
 
 
@@ -267,7 +267,7 @@ def test_run_returns_pending_removals_empty(tmp_path: Path) -> None:
 
 
 def test_run_returns_pending_removals_with_remove_sources(tmp_path: Path) -> None:
-    """run() returns PendingRemovals with remove_sources from _reconcile_playlists."""
+    """run() returns PendingRemovals with remove_sources from reconcile_playlists."""
     import unittest.mock as mock
     from music_fetch import ingest
 
@@ -280,7 +280,7 @@ def test_run_returns_pending_removals_with_remove_sources(tmp_path: Path) -> Non
          mock.patch.object(ingest, "COOKIE_FILE", cookie_file), \
          mock.patch.dict("os.environ", {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}), \
          mock.patch("shutil.disk_usage", return_value=mock.Mock(free=10 * 1024**3)), \
-         mock.patch("music_fetch.ingest._reconcile_playlists", return_value=["gone-playlist"]), \
+         mock.patch("music_fetch.ingest.reconcile_playlists", return_value=["gone-playlist"]), \
          mock.patch("music_fetch.ingest.IngestMetrics"), \
          mock.patch("music_fetch.ingest._jitter"):
         result = ingest.run()
@@ -290,8 +290,46 @@ def test_run_returns_pending_removals_with_remove_sources(tmp_path: Path) -> Non
     assert result.tracks == []
 
 
+def test_run_reconcile_failure_sets_reconcile_error_reason(tmp_path: Path) -> None:
+    """A reconcile_playlists failure sets failure_reason='reconcile_error', not 'unexpected_error'."""
+    import unittest.mock as mock
+    from music_fetch import ingest
+
+    cookie_file = tmp_path / "cookies.txt"
+    cookie_file.touch()
+
+    captured: list = []
+
+    class FakeMetrics:
+        def __init__(self):
+            self.success = True
+            self.failure_reason = ""
+            self.tracks_downloaded = 0
+            self.playlists_total = 0
+            self.playlists_skipped = 0
+            self.playlists_deferred = 0
+            self.cookies_expired = False
+            self.duration_seconds = 0
+            captured.append(self)
+
+        def push(self):
+            pass
+
+    with mock.patch.object(ingest, "COOKIE_FILE", cookie_file), \
+         mock.patch.dict("os.environ", {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}), \
+         mock.patch("shutil.disk_usage", return_value=mock.Mock(free=10 * 1024**3)), \
+         mock.patch("music_fetch.ingest.reconcile_playlists", side_effect=RuntimeError("conf error")), \
+         mock.patch("music_fetch.ingest.IngestMetrics", FakeMetrics), \
+         mock.patch("music_fetch.ingest._jitter"):
+        with pytest.raises(RuntimeError):
+            ingest.run()
+
+    assert len(captured) == 1
+    assert captured[0].failure_reason == "reconcile_error"
+
+
 # ---------------------------------------------------------------------------
-# _reconcile_playlists
+# reconcile_playlists
 # ---------------------------------------------------------------------------
 
 
@@ -308,7 +346,7 @@ def test_reconcile_no_conf(tmp_path: Path) -> None:
 
     missing = tmp_path / "playlists.conf"
     with mock.patch.object(ingest, "CONF_PATH", missing):
-        result = _reconcile_playlists()
+        result = reconcile_playlists()
 
     assert result == []
 
@@ -326,7 +364,7 @@ def test_reconcile_provisions_new_playlist(tmp_path: Path) -> None:
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch.object(ingest, "COOKIE_FILE", tmp_path / "cookies.txt"), \
          mock.patch("music_fetch.ingest.save_playlist") as mock_save:
-        result = _reconcile_playlists()
+        result = reconcile_playlists()
 
     mock_save.assert_called_once()
     call_kwargs = mock_save.call_args[1]
@@ -348,7 +386,7 @@ def test_reconcile_skips_existing_spotdl(tmp_path: Path) -> None:
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch("music_fetch.ingest.save_playlist") as mock_save:
-        result = _reconcile_playlists()
+        result = reconcile_playlists()
 
     mock_save.assert_not_called()
     assert result == []
@@ -367,7 +405,7 @@ def test_reconcile_creates_nosync_sentinel(tmp_path: Path) -> None:
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch("music_fetch.ingest.save_playlist"):
-        _reconcile_playlists()
+        reconcile_playlists()
 
     assert (spotdl_dir / "frozen.nosync").exists()
 
@@ -386,7 +424,7 @@ def test_reconcile_removes_nosync_sentinel(tmp_path: Path) -> None:
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch("music_fetch.ingest.save_playlist"):
-        _reconcile_playlists()
+        reconcile_playlists()
 
     assert not (spotdl_dir / "mypl.nosync").exists()
 
@@ -409,7 +447,7 @@ def test_reconcile_detects_removed_playlist(tmp_path: Path) -> None:
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch("music_fetch.ingest.save_playlist"):
-        result = _reconcile_playlists()
+        result = reconcile_playlists()
 
     assert result == ["gone"]
     assert not (spotdl_dir / "gone.spotdl").exists()
@@ -493,7 +531,7 @@ def test_reconcile_deletes_nosync_for_removed_playlist(tmp_path: Path) -> None:
     with mock.patch.object(ingest, "CONF_PATH", conf), \
          mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch("music_fetch.ingest.save_playlist"):
-        result = _reconcile_playlists()
+        result = reconcile_playlists()
 
     assert result == ["gone"]
     assert not (spotdl_dir / "gone.nosync").exists()

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -140,7 +140,53 @@ def _move_asis_eligible(quarantine: Path, staging: Path) -> int:
     return moved
 
 
-def _regen_playlists() -> None:
+def import_asis_from_quarantine() -> int:
+    """Import quarantine files that have sufficient existing tags (--asis).
+
+    Moves eligible files to a temp staging dir, runs ``beet import --asis``,
+    and returns any beet-skipped files back to quarantine.  Returns the count
+    of tracks imported.
+    """
+    asis_start = time.time()
+    with tempfile.TemporaryDirectory(prefix="asis-staging-") as staging_str:
+        staging = Path(staging_str)
+        staged = _move_asis_eligible(QUARANTINE, staging)
+        logger.info("Asis eligible : %d file(s) with sufficient tags", staged)
+        if staged:
+            run_beet_import(staging, asis=True)
+            for remaining in staging.rglob("*"):
+                if remaining.is_file() and remaining.suffix.lower() in AUDIO_EXTS:
+                    dest = QUARANTINE / remaining.relative_to(staging)
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.move(str(remaining), dest)
+    with MusicLibrary(LIBRARY_DB) as lib:
+        asis_imported = lib.items_added_since(asis_start)
+    logger.info("Asis pass     : %d track(s) imported from quarantine", len(asis_imported))
+    return len(asis_imported)
+
+
+def update_library() -> str | None:
+    """Refresh beets library metadata.
+
+    Skips beet update if the staging dir is empty but the DB has items, to
+    prevent DB corruption.  Returns a failure-reason string in that case, else
+    None.
+    """
+    lib_audio_count = _count_library_audio(LIBRARY_DIR)
+    with MusicLibrary(LIBRARY_DB) as lib:
+        db_item_count = lib.item_count()
+    if lib_audio_count == 0 and db_item_count > 0:
+        logger.error(
+            "staging appears empty but library has %d items — skipping beet update to prevent DB corruption"
+            " (staging_files=%d, library_items=%d)",
+            db_item_count, lib_audio_count, db_item_count,
+        )
+        return "empty_library_dir"
+    run_beet_update()
+    return None
+
+
+def regen_playlists() -> None:
     """Regenerate .m3u files for every .spotdl playlist."""
     PLAYLISTS.mkdir(parents=True, exist_ok=True)
     spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
@@ -231,41 +277,27 @@ def run(pending: PendingRemovals | None = None) -> None:
         logger.info("Log         : ~/.config/beets/import.log")
 
         logger.info("==> Importing quarantine with existing tags (--asis)...")
-        asis_start = time.time()
-        with tempfile.TemporaryDirectory(prefix="asis-staging-") as staging_str:
-            staging = Path(staging_str)
-            staged = _move_asis_eligible(QUARANTINE, staging)
-            logger.info("Asis eligible : %d file(s) with sufficient tags", staged)
-            if staged:
-                run_beet_import(staging, asis=True)
-                # Return any files beet skipped (e.g. duplicates) to quarantine
-                for remaining in staging.rglob("*"):
-                    if remaining.is_file() and remaining.suffix.lower() in AUDIO_EXTS:
-                        dest = QUARANTINE / remaining.relative_to(staging)
-                        dest.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.move(str(remaining), dest)
-        with MusicLibrary(LIBRARY_DB) as lib:
-            asis_imported = lib.items_added_since(asis_start)
-        logger.info("Asis pass     : %d track(s) imported from quarantine", len(asis_imported))
-        metrics.tracks_imported = len(imported) + len(asis_imported)
+        asis_count = 0
+        try:
+            asis_count = import_asis_from_quarantine()
+        except Exception:
+            logger.error("Asis-import step failed — continuing with library update", exc_info=True)
+        metrics.tracks_imported = len(imported) + asis_count
 
         logger.info("==> Refreshing library metadata...")
-        lib_audio_count = _count_library_audio(LIBRARY_DIR)
-        with MusicLibrary(LIBRARY_DB) as lib:
-            db_item_count = lib.item_count()
-        if lib_audio_count == 0 and db_item_count > 0:
-            logger.error(
-                "staging appears empty but library has %d items — skipping beet update to prevent DB corruption"
-                " (staging_files=%d, library_items=%d)",
-                db_item_count, lib_audio_count, db_item_count,
-            )
-            metrics.success = False
-            metrics.failure_reason = "empty_library_dir"
-        else:
-            run_beet_update()
+        try:
+            guard_reason = update_library()
+            if guard_reason:
+                metrics.success = False
+                metrics.failure_reason = guard_reason
+        except Exception:
+            logger.error("Library-update step failed — continuing with playlist regeneration", exc_info=True)
 
         logger.info("==> Regenerating playlists...")
-        _regen_playlists()
+        try:
+            regen_playlists()
+        except Exception:
+            logger.error("Playlist-regeneration step failed", exc_info=True)
 
         quarantined_after = _count_quarantine()
         metrics.quarantined_tracks = max(0, quarantined_after - quarantined_before)

--- a/scan/tests/test_scan.py
+++ b/scan/tests/test_scan.py
@@ -11,7 +11,7 @@ from music_fetch.ingest import PendingRemovals, RemovedTrack
 
 
 def _relative_path(track_path: Path, playlists_dir: Path) -> str:
-    """Replicate the relative-path logic used in _regen_playlists."""
+    """Replicate the relative-path logic used in regen_playlists."""
     return os.path.relpath(track_path, playlists_dir)
 
 
@@ -247,13 +247,58 @@ def test_run_pending_removals_failure_continues_to_import(tmp_path: Path) -> Non
     assert import_called, "import should proceed even when pending-removals raises"
 
 
+def test_run_asis_import_failure_continues_to_beet_update(tmp_path: Path) -> None:
+    """A failure in import_asis_from_quarantine is logged but does not suppress beet update."""
+    from music_scan import scan
+
+    update_called = []
+
+    with mock.patch("music_scan.scan.import_asis_from_quarantine", side_effect=RuntimeError("staging error")), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=_make_mock_lib()), \
+         mock.patch("music_scan.scan.run_beet_import"), \
+         mock.patch("music_scan.scan.run_beet_update", side_effect=lambda: update_called.append(True)), \
+         mock.patch("music_scan.scan.INBOX", tmp_path), \
+         mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
+         mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.LIBRARY_DIR", tmp_path), \
+         mock.patch("music_scan.scan.ScanMetrics"), \
+         mock.patch("music_scan.scan.trigger_scan"):
+        scan.run(pending=None)
+
+    assert update_called, "beet update should proceed even when asis-import raises"
+
+
+def test_run_library_update_failure_continues_to_regen_playlists(tmp_path: Path) -> None:
+    """A failure in update_library is logged but does not suppress playlist regeneration."""
+    from music_scan import scan
+
+    regen_called = []
+
+    with mock.patch("music_scan.scan.update_library", side_effect=RuntimeError("db gone")), \
+         mock.patch("music_scan.scan.MusicLibrary", return_value=_make_mock_lib()), \
+         mock.patch("music_scan.scan.run_beet_import"), \
+         mock.patch("music_scan.scan.regen_playlists", side_effect=lambda: regen_called.append(True)), \
+         mock.patch("music_scan.scan.import_asis_from_quarantine", return_value=0), \
+         mock.patch("music_scan.scan.INBOX", tmp_path), \
+         mock.patch("music_scan.scan.SPOTDL_DIR", tmp_path), \
+         mock.patch("music_scan.scan.QUARANTINE", tmp_path), \
+         mock.patch("music_scan.scan.PLAYLISTS", tmp_path), \
+         mock.patch("music_scan.scan.LIBRARY_DIR", tmp_path), \
+         mock.patch("music_scan.scan.ScanMetrics"), \
+         mock.patch("music_scan.scan.trigger_scan"):
+        scan.run(pending=None)
+
+    assert regen_called, "regen_playlists should proceed even when update_library raises"
+
+
 # ---------------------------------------------------------------------------
-# _regen_playlists
+# regen_playlists
 # ---------------------------------------------------------------------------
 
 
 def test_regen_playlists_writes_m3u_with_relative_paths(tmp_path: Path) -> None:
-    from music_scan.scan import _regen_playlists
+    from music_scan.scan import regen_playlists
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -273,7 +318,7 @@ def test_regen_playlists_writes_m3u_with_relative_paths(tmp_path: Path) -> None:
          mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
          mock.patch("music_scan.scan.LIBRARY_DB", tmp_path / "library.db"), \
          mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        _regen_playlists()
+        regen_playlists()
 
     m3u = playlists_dir / "my-playlist.m3u"
     assert m3u.exists()
@@ -284,7 +329,7 @@ def test_regen_playlists_writes_m3u_with_relative_paths(tmp_path: Path) -> None:
 
 
 def test_regen_playlists_empty_playlist_writes_empty_m3u(tmp_path: Path) -> None:
-    from music_scan.scan import _regen_playlists
+    from music_scan.scan import regen_playlists
 
     spotdl_dir = tmp_path / "spotdl"
     spotdl_dir.mkdir()
@@ -302,7 +347,7 @@ def test_regen_playlists_empty_playlist_writes_empty_m3u(tmp_path: Path) -> None
          mock.patch("music_scan.scan.PLAYLISTS", playlists_dir), \
          mock.patch("music_scan.scan.LIBRARY_DB", tmp_path / "library.db"), \
          mock.patch("music_scan.scan.MusicLibrary", return_value=mock_lib):
-        _regen_playlists()
+        regen_playlists()
 
     m3u = playlists_dir / "empty-playlist.m3u"
     assert m3u.exists()


### PR DESCRIPTION
Closes #87, #88, #89, #90

## Summary

- **scan: `import_asis_from_quarantine()`** (#87) — extracted from `run()`, wrapped in its own try/except so asis-import failure doesn't suppress library update
- **scan: `update_library()`** (#88) — extracted from `run()`, returns `"empty_library_dir"` when the safety guard fires; failure doesn't suppress playlist regeneration  
- **scan: `regen_playlists()`** (#89) — `_regen_playlists()` promoted to public callable, wrapped in its own try/except (HTTP endpoint deferred to follow-up)
- **fetch: `reconcile_playlists()` + `sync_playlists()`** (#90) — `_reconcile_playlists()` made public; download loop extracted into `sync_playlists(remove_sources, metrics, start)`; reconcile failures now get `failure_reason="reconcile_error"` instead of `"unexpected_error"`

Each extraction follows the same pattern: standalone callable + named step in the orchestrator + failure-isolation test.

## Test plan
- [ ] CI passes
- [ ] New failure-isolation tests: `test_run_asis_import_failure_continues_to_beet_update`, `test_run_library_update_failure_continues_to_regen_playlists`, `test_run_reconcile_failure_sets_reconcile_error_reason`

🤖 Generated with [Claude Code](https://claude.com/claude-code)