### PR TITLE
feat: make rclone tracks and playlists destinations configurable

### DIFF
--- a/service/music_service/orchestrator.py
+++ b/service/music_service/orchestrator.py
@@ -83,13 +83,15 @@ class Orchestrator:
             logger.info("LIBRARY_REMOTE not set — skipping library push")
             return False
 
+        tracks_remote = os.environ.get("LIBRARY_TRACKS_REMOTE", f"{remote}/tracks")
+        playlists_remote = os.environ.get("LIBRARY_PLAYLISTS_REMOTE", f"{remote}/playlists")
         staging = Path(os.environ.get("MUSIC_STAGING", "/root/Music/staging"))
         playlists = Path(os.environ.get("MUSIC_PLAYLISTS", "/root/Music/playlists"))
 
-        subprocess.run(["rclone", "copy", str(staging), remote], check=True)
-        subprocess.run(["rclone", "sync", str(playlists), f"{remote}/playlists"], check=True)
+        subprocess.run(["rclone", "copy", str(staging), tracks_remote], check=True)
+        subprocess.run(["rclone", "sync", str(playlists), playlists_remote], check=True)
 
-        logger.info("==> Library pushed to %s", remote)
+        logger.info("==> Library pushed to %s", tracks_remote)
         return True
 
     # ------------------------------------------------------------------

--- a/service/tests/test_orchestrator.py
+++ b/service/tests/test_orchestrator.py
@@ -176,8 +176,44 @@ def test_push_library_calls_rclone_copy_then_sync(monkeypatch, tmp_path):
 
     assert mock_sub.run.call_count == 2
     copy_call, sync_call = mock_sub.run.call_args_list
-    assert copy_call == call(["rclone", "copy", str(staging), remote], check=True)
+    assert copy_call == call(["rclone", "copy", str(staging), f"{remote}/tracks"], check=True)
     assert sync_call == call(["rclone", "sync", str(playlists), f"{remote}/playlists"], check=True)
+
+
+def test_push_library_uses_tracks_remote_when_set(monkeypatch, tmp_path):
+    """LIBRARY_TRACKS_REMOTE overrides LIBRARY_REMOTE for the rclone copy."""
+    staging = tmp_path / "staging"
+    playlists = tmp_path / "playlists"
+    monkeypatch.setenv("LIBRARY_REMOTE", "navidrome:")
+    monkeypatch.setenv("LIBRARY_TRACKS_REMOTE", "navidrome:tracks")
+    monkeypatch.setenv("MUSIC_STAGING", str(staging))
+    monkeypatch.setenv("MUSIC_PLAYLISTS", str(playlists))
+
+    orc = Orchestrator()
+    with patch("music_service.orchestrator.subprocess") as mock_sub:
+        orc._push_library()
+
+    copy_call, sync_call = mock_sub.run.call_args_list
+    assert copy_call == call(["rclone", "copy", str(staging), "navidrome:tracks"], check=True)
+    assert sync_call == call(["rclone", "sync", str(playlists), "navidrome:/playlists"], check=True)
+
+
+def test_push_library_uses_playlists_remote_when_set(monkeypatch, tmp_path):
+    """LIBRARY_PLAYLISTS_REMOTE overrides the default {LIBRARY_REMOTE}/playlists destination."""
+    staging = tmp_path / "staging"
+    playlists = tmp_path / "playlists"
+    monkeypatch.setenv("LIBRARY_REMOTE", "navidrome:")
+    monkeypatch.setenv("LIBRARY_PLAYLISTS_REMOTE", "navidrome:playlists")
+    monkeypatch.setenv("MUSIC_STAGING", str(staging))
+    monkeypatch.setenv("MUSIC_PLAYLISTS", str(playlists))
+
+    orc = Orchestrator()
+    with patch("music_service.orchestrator.subprocess") as mock_sub:
+        orc._push_library()
+
+    copy_call, sync_call = mock_sub.run.call_args_list
+    assert copy_call == call(["rclone", "copy", str(staging), "navidrome:/tracks"], check=True)
+    assert sync_call == call(["rclone", "sync", str(playlists), "navidrome:playlists"], check=True)
 
 
 def test_push_library_uses_default_paths_when_env_unset(monkeypatch):
@@ -191,7 +227,7 @@ def test_push_library_uses_default_paths_when_env_unset(monkeypatch):
         orc._push_library()
 
     copy_call, sync_call = mock_sub.run.call_args_list
-    assert copy_call == call(["rclone", "copy", "/root/Music/staging", ":webdav:"], check=True)
+    assert copy_call == call(["rclone", "copy", "/root/Music/staging", ":webdav:/tracks"], check=True)
     assert sync_call == call(["rclone", "sync", "/root/Music/playlists", ":webdav:/playlists"], check=True)
 
 


### PR DESCRIPTION
Closes #97.

## Summary

- `LIBRARY_TRACKS_REMOTE` — overrides the destination for `rclone copy` of tracks. Defaults to `{LIBRARY_REMOTE}/tracks`.
- `LIBRARY_PLAYLISTS_REMOTE` — overrides the destination for `rclone sync` of playlists. Defaults to `{LIBRARY_REMOTE}/playlists`.

Both vars are optional; when unset behaviour is unchanged relative to a fresh deployment (tracks and playlists land in `tracks/` and `playlists/` subdirectories of the remote root).

The homelab deployment sets `LIBRARY_REMOTE=navidrome:` and leaves both new vars unset, which now correctly routes files to `navidrome:/tracks` (the path Navidrome scans via its `subPath: tracks` mount) and `navidrome:/playlists`.

## Test plan

- [ ] `just test` passes
- [ ] Verify existing `test_push_library_*` tests cover default-fallback behaviour
- [ ] Two new tests cover explicit `LIBRARY_TRACKS_REMOTE` and `LIBRARY_PLAYLISTS_REMOTE` overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)