### PR TITLE
fix: store spotify_url in beets DB to survive scrub plugin (#100)

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,6 +48,13 @@ scan:
 sync:
     just fetch && just scan
 
+# One-time migration: populate spotify_url flex attr for items imported before #100 fix.
+# Pass --dry-run to preview, --playlist <name> to limit to one playlist.
+backfill-spotify-urls *args:
+    docker compose run --rm \
+        --volume {{justfile_directory()}}/scripts/backfill-spotify-urls.py:/tmp/backfill-spotify-urls.py \
+        service python3 /tmp/backfill-spotify-urls.py {{args}}
+
 # Dump beets DB and export JSON from the container
 backup:
     docker compose run --rm service sh -c "beet export > /root/.config/beets/library-export.json"

--- a/scan/music_scan/library.py
+++ b/scan/music_scan/library.py
@@ -56,6 +56,14 @@ class MusicLibrary:
             for item in items
         ]
 
+    def spotify_urls_by_source(self, source: str) -> frozenset[str]:
+        """Spotify URLs stored as flex attr for all items with the given source tag."""
+        return frozenset(
+            item.get("spotify_url")
+            for item in self.items_by_source(source)
+            if item.get("spotify_url")
+        )
+
     # ------------------------------------------------------------------
     # Modification helpers
     # ------------------------------------------------------------------

--- a/scan/music_scan/music_pipeline.py
+++ b/scan/music_scan/music_pipeline.py
@@ -75,6 +75,27 @@ SPOTDL_INBOX = Path("/root/Music/inbox/spotdl")
 #    preserving the spotdl/<playlist>/ subdirectory structure.
 ASIS_STAGING_ROOT = Path("/tmp")
 
+
+def _read_spotify_url(path: str | bytes) -> str | None:
+    """Return the Spotify URL embedded in an M4A file by spotdl, or None.
+
+    Called during import_task_created while item.path still points to the
+    inbox file — before the scrub plugin strips the freeform MP4 atom.
+    """
+    try:
+        from mutagen.mp4 import MP4  # noqa: PLC0415 — beets dep, always available
+
+        if isinstance(path, bytes):
+            path = path.decode()
+        audio = MP4(path)
+        raw = (audio.tags or {}).get("----:spotdl:WOAS")
+        if raw:
+            return raw[0].decode("utf-8")
+    except Exception:
+        pass
+    return None
+
+
 # Actions that indicate the task will actually be applied to the library.
 # Matches the guard used by beets' own _resolve_duplicates().
 _WILL_APPLY = (
@@ -137,6 +158,7 @@ class MusicPipelinePlugin(BeetsPlugin):
         # so the filename key no longer matches at item_imported time.
         # The title key survives both the rename and MB autotag metadata replacement.
         self._pending_sources: dict[str, str] = {}
+        self._pending_spotify_urls: dict[str, str] = {}
         self.register_listener("import_task_created", self.tag_source_on_created)
         self.register_listener("item_imported", self.tag_source_on_stored)
         self.register_listener("import_task_choice", self.handle_duplicates)
@@ -160,10 +182,17 @@ class MusicPipelinePlugin(BeetsPlugin):
             item["source"] = playlist
             item["via"] = "spotdl"
             path = item.path.decode() if isinstance(item.path, bytes) else item.path
-            self._pending_sources[Path(path).name] = playlist
+            filename = Path(path).name
+            self._pending_sources[filename] = playlist
             title = (item.title or "").lower()
             if title:
                 self._pending_sources[title] = playlist
+            spotify_url = _read_spotify_url(item.path)
+            if spotify_url:
+                item["spotify_url"] = spotify_url
+                self._pending_spotify_urls[filename] = spotify_url
+                if title:
+                    self._pending_spotify_urls[title] = spotify_url
             self._log.debug(
                 "tagged incoming track source={} via=spotdl: {}", playlist, item.path
             )
@@ -195,6 +224,15 @@ class MusicPipelinePlugin(BeetsPlugin):
             return
         item["source"] = playlist
         item["via"] = "spotdl"
+        filename = Path(path).name
+        spotify_url = self._pending_spotify_urls.pop(filename, None)
+        if spotify_url is not None:
+            if title:
+                self._pending_spotify_urls.pop(title, None)
+        elif title:
+            spotify_url = self._pending_spotify_urls.pop(title, None)
+        if spotify_url:
+            item["spotify_url"] = spotify_url
         item.store()
         self._log.debug(
             "persisted source={} via=spotdl on stored item: {}", playlist, item.path

--- a/scan/music_scan/reconcile.py
+++ b/scan/music_scan/reconcile.py
@@ -71,18 +71,7 @@ def reconcile_snapshot(
 
     playlist_name = spotdl_file.stem
 
-    # Build verified URL set from beets library paths for this playlist.
-    library_urls: set[str] = set()
-    for path in library.paths_by_source(playlist_name):
-        if not path.exists():
-            logger.warning("Beets has stale path for %s: %s", playlist_name, path)
-            continue
-        url = _read_spotify_url(path)
-        if url:
-            library_urls.add(url)
-        else:
-            logger.warning("Could not read Spotify URL from library file: %s", path)
-
+    library_urls = library.spotify_urls_by_source(playlist_name)
     all_safe = library_urls | safe_urls
 
     kept: list[dict] = []

--- a/scan/tests/test_music_pipeline.py
+++ b/scan/tests/test_music_pipeline.py
@@ -24,6 +24,7 @@ def _make_plugin() -> MusicPipelinePlugin:
     plugin = MusicPipelinePlugin.__new__(MusicPipelinePlugin)
     plugin._log = MagicMock()
     plugin._pending_sources = {}
+    plugin._pending_spotify_urls = {}
     return plugin
 
 
@@ -354,3 +355,87 @@ def test_handle_duplicates_manual_duplicate_deletes_inbox_file() -> None:
         plugin.handle_duplicates(session=MagicMock(), task=task)
 
     mock_path.return_value.unlink.assert_called_once_with(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# MusicPipelinePlugin.tag_source_on_created — spotify_url capture
+# ---------------------------------------------------------------------------
+
+
+def test_tag_source_on_created_sets_spotify_url_and_caches() -> None:
+    """Spotify URL read from the inbox file is set on the item and cached."""
+    plugin = _make_plugin()
+    item = _item("/root/Music/inbox/spotdl/jazz/Artist - My Track.m4a", title="My Track")
+    task = _task(item=item)
+
+    with patch("music_scan.music_pipeline._read_spotify_url", return_value="https://open.spotify.com/track/X"):
+        plugin.tag_source_on_created(session=MagicMock(), task=task)
+
+    item.__setitem__.assert_any_call("spotify_url", "https://open.spotify.com/track/X")
+    assert plugin._pending_spotify_urls["Artist - My Track.m4a"] == "https://open.spotify.com/track/X"
+    assert plugin._pending_spotify_urls["my track"] == "https://open.spotify.com/track/X"
+
+
+def test_tag_source_on_created_no_spotify_url_does_not_set_or_cache() -> None:
+    """When no Spotify URL is in the inbox file, spotify_url is not set."""
+    plugin = _make_plugin()
+    item = _item("/root/Music/inbox/spotdl/jazz/track.m4a", title="Track")
+    task = _task(item=item)
+
+    with patch("music_scan.music_pipeline._read_spotify_url", return_value=None):
+        plugin.tag_source_on_created(session=MagicMock(), task=task)
+
+    written_keys = [c[0][0] for c in item.__setitem__.call_args_list]
+    assert "spotify_url" not in written_keys
+    assert plugin._pending_spotify_urls == {}
+
+
+# ---------------------------------------------------------------------------
+# MusicPipelinePlugin.tag_source_on_stored — spotify_url persistence
+# ---------------------------------------------------------------------------
+
+
+def test_tag_source_on_stored_persists_spotify_url_via_title_key() -> None:
+    """spotify_url is persisted via the title key (common case after beets renames the file)."""
+    plugin = _make_plugin()
+    plugin._pending_sources = {
+        "Artist - My Track.m4a": "jazz",
+        "my track": "jazz",
+    }
+    plugin._pending_spotify_urls = {
+        "Artist - My Track.m4a": "https://open.spotify.com/track/X",
+        "my track": "https://open.spotify.com/track/X",
+    }
+    item = _item("/root/Music/library/Artist/Album/03 - My Track.m4a", title="My Track")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    item.__setitem__.assert_any_call("spotify_url", "https://open.spotify.com/track/X")
+    item.store.assert_called_once()
+
+
+def test_tag_source_on_stored_persists_spotify_url_via_filename_key() -> None:
+    """spotify_url is persisted via the filename key when the file was not renamed."""
+    plugin = _make_plugin()
+    plugin._pending_sources = {"track.m4a": "jazz"}
+    plugin._pending_spotify_urls = {"track.m4a": "https://open.spotify.com/track/Y"}
+    item = _item("/root/Music/library/Artist/Album/track.m4a", title="Track")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    item.__setitem__.assert_any_call("spotify_url", "https://open.spotify.com/track/Y")
+    item.store.assert_called_once()
+
+
+def test_tag_source_on_stored_no_spotify_url_does_not_set() -> None:
+    """When no spotify_url was cached (e.g. file had no WOAS tag), it is not written."""
+    plugin = _make_plugin()
+    plugin._pending_sources = {"track.m4a": "jazz"}
+    # _pending_spotify_urls intentionally empty
+    item = _item("/root/Music/library/Artist/Album/track.m4a", title="Track")
+
+    plugin.tag_source_on_stored(lib=MagicMock(), item=item)
+
+    written_keys = [c[0][0] for c in item.__setitem__.call_args_list]
+    assert "spotify_url" not in written_keys
+    item.store.assert_called_once()

--- a/scan/tests/test_reconcile.py
+++ b/scan/tests/test_reconcile.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import unittest.mock as mock
 from pathlib import Path
-
-import pytest
 
 from music_scan.reconcile import reconcile_snapshot
 
@@ -26,18 +25,9 @@ def _write_snapshot(path: Path, playlist_name: str, urls: list[str]) -> Path:
     return spotdl_file
 
 
-def _make_library_paths(base: Path, count: int) -> list[Path]:
-    staging = base / "staging"
-    staging.mkdir(exist_ok=True)
-    paths = [staging / f"track_{i}.m4a" for i in range(count)]
-    for p in paths:
-        p.touch()
-    return paths
-
-
-def _mock_library(paths: list[Path]) -> mock.Mock:
+def _mock_library(spotify_urls: frozenset[str]) -> mock.Mock:
     lib = mock.Mock()
-    lib.paths_by_source.return_value = paths
+    lib.spotify_urls_by_source.return_value = spotify_urls
     return lib
 
 
@@ -47,18 +37,16 @@ def _mock_library(paths: list[Path]) -> mock.Mock:
 
 
 def test_reconcile_all_present_no_changes(tmp_path: Path) -> None:
-    """When every snapshot URL has a matching file in the library, nothing is dropped."""
+    """When every snapshot URL has a matching entry in the library DB, nothing is dropped."""
     urls = [
         "https://open.spotify.com/track/A",
         "https://open.spotify.com/track/B",
         "https://open.spotify.com/track/C",
     ]
     spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
-    lib_paths = _make_library_paths(tmp_path, len(urls))
-    lib = _mock_library(lib_paths)
+    lib = _mock_library(frozenset(urls))
 
-    with mock.patch("music_scan.reconcile._read_spotify_url", side_effect=urls):
-        dropped = reconcile_snapshot(spotdl_file, lib)
+    dropped = reconcile_snapshot(spotdl_file, lib)
 
     assert dropped == 0
     data = json.loads(spotdl_file.read_text(encoding="utf-8"))
@@ -78,15 +66,12 @@ def test_reconcile_one_missing_dropped(tmp_path: Path) -> None:
         "https://open.spotify.com/track/C",
     ]
     spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
-    # Library only has A and B
-    lib_paths = _make_library_paths(tmp_path, 2)
-    lib = _mock_library(lib_paths)
+    lib = _mock_library(frozenset([
+        "https://open.spotify.com/track/A",
+        "https://open.spotify.com/track/B",
+    ]))
 
-    with mock.patch(
-        "music_scan.reconcile._read_spotify_url",
-        side_effect=["https://open.spotify.com/track/A", "https://open.spotify.com/track/B"],
-    ):
-        dropped = reconcile_snapshot(spotdl_file, lib)
+    dropped = reconcile_snapshot(spotdl_file, lib)
 
     assert dropped == 1
     data = json.loads(spotdl_file.read_text(encoding="utf-8"))
@@ -97,18 +82,12 @@ def test_reconcile_one_missing_dropped(tmp_path: Path) -> None:
 
 def test_reconcile_one_missing_logs_warning(tmp_path: Path, caplog) -> None:
     """A WARNING is emitted for each dropped URL."""
-    import logging
-
     urls = ["https://open.spotify.com/track/A", "https://open.spotify.com/track/B"]
     spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
-    lib = _mock_library(_make_library_paths(tmp_path, 1))
+    lib = _mock_library(frozenset(["https://open.spotify.com/track/A"]))
 
-    with mock.patch(
-        "music_scan.reconcile._read_spotify_url",
-        side_effect=["https://open.spotify.com/track/A"],
-    ):
-        with caplog.at_level(logging.WARNING, logger="music_scan.reconcile"):
-            reconcile_snapshot(spotdl_file, lib)
+    with caplog.at_level(logging.WARNING, logger="music_scan.reconcile"):
+        reconcile_snapshot(spotdl_file, lib)
 
     assert any("https://open.spotify.com/track/B" in r.message for r in caplog.records)
 
@@ -122,7 +101,7 @@ def test_reconcile_all_missing_drops_all(tmp_path: Path) -> None:
     """When no URLs are in the library or quarantine, all are dropped."""
     urls = ["https://open.spotify.com/track/A", "https://open.spotify.com/track/B"]
     spotdl_file = _write_snapshot(tmp_path, "mypl", urls)
-    lib = _mock_library([])
+    lib = _mock_library(frozenset())
 
     dropped = reconcile_snapshot(spotdl_file, lib)
 
@@ -141,38 +120,13 @@ def test_reconcile_quarantined_url_not_dropped(tmp_path: Path) -> None:
     url_a = "https://open.spotify.com/track/A"
     url_b = "https://open.spotify.com/track/B"
     spotdl_file = _write_snapshot(tmp_path, "mypl", [url_a, url_b])
+    lib = _mock_library(frozenset([url_a]))
 
-    lib_paths = _make_library_paths(tmp_path, 1)
-    lib = _mock_library(lib_paths)
-
-    # A is in the library; B is in quarantine (passed as safe_urls)
-    with mock.patch("music_scan.reconcile._read_spotify_url", return_value=url_a):
-        dropped = reconcile_snapshot(spotdl_file, lib, safe_urls={url_b})
+    dropped = reconcile_snapshot(spotdl_file, lib, safe_urls={url_b})
 
     assert dropped == 0
     data = json.loads(spotdl_file.read_text(encoding="utf-8"))
     assert {s["url"] for s in data["songs"]} == {url_a, url_b}
-
-
-# ---------------------------------------------------------------------------
-# reconcile_snapshot — stale beets paths handled gracefully
-# ---------------------------------------------------------------------------
-
-
-def test_reconcile_stale_library_path_treated_as_missing(tmp_path: Path) -> None:
-    """A beets library entry whose file no longer exists is not counted as verified."""
-    url = "https://open.spotify.com/track/A"
-    spotdl_file = _write_snapshot(tmp_path, "mypl", [url])
-
-    # Library returns a path that does not exist on disk
-    ghost_path = tmp_path / "staging" / "ghost.m4a"
-    lib = _mock_library([ghost_path])
-
-    dropped = reconcile_snapshot(spotdl_file, lib)
-
-    assert dropped == 1
-    data = json.loads(spotdl_file.read_text(encoding="utf-8"))
-    assert data["songs"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -186,9 +140,9 @@ def test_reconcile_empty_snapshot_no_op(tmp_path: Path) -> None:
         json.dumps({"type": "sync", "query": ["https://..."], "songs": []}),
         encoding="utf-8",
     )
-    lib = _mock_library([])
+    lib = mock.Mock()
 
     dropped = reconcile_snapshot(spotdl_file, lib)
 
     assert dropped == 0
-    lib.paths_by_source.assert_not_called()
+    lib.spotify_urls_by_source.assert_not_called()

--- a/scripts/backfill-spotify-urls.py
+++ b/scripts/backfill-spotify-urls.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""One-shot migration: populate spotify_url flex attr in beets DB from .spotdl snapshots.
+
+Before this migration the beets scrub plugin (auto: yes) stripped the
+----:spotdl:WOAS freeform tag on import, so reconcile_snapshot always saw
+an empty library_urls set and dropped every snapshot entry as stale.
+
+This script reads each .spotdl snapshot, matches its songs against beets
+items by normalised title, and writes spotify_url= on each matched item so
+that reconcile can verify them without re-reading file tags.
+
+Run once after deploying the fix for #100:
+    just backfill-spotify-urls [-- --dry-run] [-- --playlist <name>]
+
+The script matches on normalised title (lowercase, punctuation stripped).
+When a title is ambiguous (multiple library items match a single Spotify
+title) it skips — manual review is safer than a wrong URL.
+
+Exit codes: 0 = success, 1 = error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
+LIBRARY_DB = Path("/root/.config/beets/library.db")
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^\w\s]", "", s.lower()).strip()
+
+
+def backfill_playlist(lib, playlist_name: str, dry_run: bool) -> tuple[int, int, int]:
+    """Backfill spotify_url for one playlist. Returns (updated, skipped_ambiguous, no_match)."""
+    spotdl_file = SPOTDL_DIR / f"{playlist_name}.spotdl"
+    if not spotdl_file.exists():
+        print(f"  WARNING: {spotdl_file} not found — skipping", file=sys.stderr)
+        return 0, 0, 0
+
+    with open(spotdl_file, encoding="utf-8") as fh:
+        data = json.load(fh)
+    songs = data.get("songs", []) if isinstance(data, dict) else data
+
+    url_by_norm: dict[str, str] = {}
+    for song in songs:
+        name = song.get("name") or ""
+        url = song.get("url") or ""
+        if name and url:
+            url_by_norm[_norm(name)] = url
+
+    items = list(lib.items(f"source:{playlist_name}"))
+    needs_url = [item for item in items if not (item.get("spotify_url") or "")]
+
+    if not needs_url:
+        print(f"{playlist_name}: all {len(items)} item(s) already have spotify_url — nothing to do")
+        return 0, 0, 0
+
+    print(f"{playlist_name}: {len(needs_url)}/{len(items)} item(s) need spotify_url")
+
+    # Build title → [items] map within this playlist to detect ambiguity
+    title_map: dict[str, list] = {}
+    for item in needs_url:
+        key = _norm(item.title or "")
+        if key:
+            title_map.setdefault(key, []).append(item)
+
+    updated = skipped_ambiguous = no_match = 0
+
+    for norm_title, candidates in sorted(title_map.items()):
+        url = url_by_norm.get(norm_title)
+        if not url:
+            no_match += len(candidates)
+            for item in candidates:
+                print(f"  [NO MATCH] {item.title!r} — {item.artist!r}")
+            continue
+
+        if len(candidates) > 1:
+            skipped_ambiguous += len(candidates)
+            print(f"  [AMBIGUOUS] {len(candidates)} items share title {norm_title!r} — skipped:")
+            for item in candidates:
+                print(f"    id={item.id}  {item.title!r} — {item.artist!r}")
+            continue
+
+        item = candidates[0]
+        action = "DRY-RUN" if dry_run else "SET"
+        print(f"  [{action}] spotify_url → {item.title!r} — {item.artist!r}")
+        if not dry_run:
+            item["spotify_url"] = url
+            item.store()
+        updated += 1
+
+    return updated, skipped_ambiguous, no_match
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--playlist", help="Limit to one playlist name (default: all)")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would change; don't write")
+    args = parser.parse_args()
+
+    if not LIBRARY_DB.exists():
+        print(f"ERROR: {LIBRARY_DB} not found", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from beets.library import Library
+    except ImportError:
+        print("ERROR: beets not installed in this environment", file=sys.stderr)
+        sys.exit(1)
+
+    lib = Library(str(LIBRARY_DB))
+
+    if args.playlist:
+        playlists = [args.playlist]
+    else:
+        playlists = [f.stem for f in sorted(SPOTDL_DIR.glob("*.spotdl"))]
+
+    if not playlists:
+        print("No .spotdl files found.")
+        lib._close()
+        return
+
+    if args.dry_run:
+        print("--- DRY RUN — no changes will be written ---\n")
+
+    total_updated = total_ambiguous = total_no_match = 0
+    for playlist in playlists:
+        updated, ambiguous, no_match = backfill_playlist(lib, playlist, args.dry_run)
+        total_updated += updated
+        total_ambiguous += ambiguous
+        total_no_match += no_match
+
+    lib._close()
+
+    print()
+    print(f"Total: {total_updated} updated, {total_ambiguous} skipped (ambiguous title), {total_no_match} no match in snapshot")
+    if args.dry_run:
+        print("(dry-run — no changes written)")
+    if total_no_match:
+        print("No-match items may have titles that differ significantly after MusicBrainz tagging.")
+        print("Check these manually: beet ls source:<playlist> ^spotify_url:.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- The beets `scrub` plugin (`auto: yes`) strips `----:spotdl:WOAS` from M4A files on import
- `reconcile_snapshot()` read that tag via mutagen to verify which URLs are in the library — but since scrub strips it, `library_urls` was always empty, causing all snapshot entries to be dropped as stale every run
- With a 25-track budget the same 25 tracks were re-downloaded in perpetuity and never advanced

**Fix (Option B from issue):** capture the Spotify URL from the inbox file during `import_task_created` (before scrub runs) and persist it as a `spotify_url` flex attribute in the beets library DB. `reconcile_snapshot` now queries the DB via `library.spotify_urls_by_source()` instead of re-reading stripped file tags — fully scrub-proof.

This fix also unblocks the #85 architecture change: Option B there was rejected specifically because the old reconcile verified by reading file tags — if staging was cleared, all URLs would be dropped.

## Migration for existing items

Items imported before this fix have no `spotify_url` in the DB. Run once after deploying:

```bash
# Preview
just backfill-spotify-urls --dry-run

# Apply
just backfill-spotify-urls
```

In k8s:
```bash
kubectl cp scripts/backfill-spotify-urls.py <pod>:/tmp/backfill-spotify-urls.py
kubectl exec -it <pod> -- python3 /tmp/backfill-spotify-urls.py --dry-run
kubectl exec -it <pod> -- python3 /tmp/backfill-spotify-urls.py
```

Matches existing items to their Spotify URL by normalised title. Ambiguous or unmatched items are logged but not touched — review manually with `beet ls source:<playlist>`.

## Changes

- `scan/music_scan/music_pipeline.py` — read `----:spotdl:WOAS` in `tag_source_on_created` (pre-scrub), persist as `spotify_url` flex attr in `tag_source_on_stored`
- `scan/music_scan/library.py` — add `spotify_urls_by_source()` DB query method
- `scan/music_scan/reconcile.py` — replace file-tag reading loop with `library.spotify_urls_by_source()`
- `scripts/backfill-spotify-urls.py` — one-time migration script for existing items
- `justfile` — `just backfill-spotify-urls` recipe
- `scan/tests/` — update mocks; add 5 new tests for spotify_url capture

## Test plan

- [x] 39 tests pass (6 reconcile + 33 music_pipeline)
- [x] New tests cover: URL captured and cached in `tag_source_on_created`, persisted via both filename and title key in `tag_source_on_stored`, absent URL does not set the attribute

Fixes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)