### PR TITLE
feat: exponential backoff for unfindable tracks

### DIFF
--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -31,6 +31,7 @@ from music_fetch.spotdl_ops import find_track_in_snapshot, save_playlist, sync_p
 logger = logging.getLogger(__name__)
 
 SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
+FAILURES_FILE = SPOTDL_DIR.parent / ".spotdl-failures.json"
 COOKIE_FILE = Path("/root/.config/spotdl/cookies.txt")
 CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
 
@@ -279,6 +280,7 @@ def sync_playlists(
                 output_dir=output_dir,
                 cookie_file=COOKIE_FILE,
                 track_limit=remaining,
+                failures_file=FAILURES_FILE,
             )
         except Exception as exc:
             reason = classify_failure(str(exc))
@@ -321,6 +323,7 @@ def run() -> PendingRemovals:
 
     try:
         logger.info("==> music-ingest starting")
+        logger.info("MISS backoff state: %s", FAILURES_FILE)
 
         logger.info("==> Reconciling playlists...")
         try:

--- a/fetch/music_fetch/spotdl_ops.py
+++ b/fetch/music_fetch/spotdl_ops.py
@@ -11,11 +11,32 @@ from __future__ import annotations
 import json
 import logging
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _spotdl_instance = None  # process-wide singleton (SpotifyClient + ProgressHandler can't be reinitialised)
+
+_BACKOFF_SCHEDULE = [7, 14, 28]  # days; last value repeats indefinitely
+
+
+def _backoff_days(attempts: int) -> int:
+    return _BACKOFF_SCHEDULE[min(attempts, len(_BACKOFF_SCHEDULE)) - 1]
+
+
+def _load_failures(failures_file: Path) -> dict:
+    if not failures_file.exists():
+        return {}
+    try:
+        return json.loads(failures_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Could not read %s — treating as empty", failures_file)
+        return {}
+
+
+def _save_failures(failures_file: Path, data: dict) -> None:
+    failures_file.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
 def _song_label(song) -> str:
@@ -101,6 +122,7 @@ def sync_playlist(
     output_dir: Path,
     cookie_file: Path,
     track_limit: int | None = None,
+    failures_file: Path | None = None,
 ) -> tuple[set[str], int]:
     """Sync a playlist from its .spotdl file.
 
@@ -155,6 +177,25 @@ def sync_playlist(
 
     # Identify tracks not yet downloaded (absent from the previous snapshot).
     truly_new = [s for s in new_songs if s.url not in old_urls]
+
+    # Apply MISS backoff: filter out tracks whose retry window hasn't expired yet.
+    failures: dict = {}
+    if failures_file is not None:
+        failures = _load_failures(failures_file)
+        for url in removed_urls:
+            failures.pop(url, None)
+        now = datetime.now(timezone.utc)
+        due, backed_off = [], []
+        for song in truly_new:
+            entry = failures.get(song.url)
+            if entry and datetime.fromisoformat(entry["retry_after"]) > now:
+                backed_off.append(song)
+            else:
+                due.append(song)
+        for song in backed_off:
+            logger.info("[BACK] %s → backed off until %s", _song_label(song), failures[song.url]["retry_after"][:10])
+        truly_new = due
+
     total_new = len(truly_new)
 
     if track_limit is not None and total_new > track_limit:
@@ -178,10 +219,19 @@ def sync_playlist(
     for song, path in results:
         if path is not None:
             logger.info("[OK]   %s", _song_label(song))
+            failures.pop(song.url, None)
         elif getattr(song, "download_url", None):
             logger.info("[FAIL] %s → download failed", _song_label(song))
         else:
-            logger.info("[MISS] %s → no source found", _song_label(song))
+            entry = failures.get(song.url, {"attempts": 0})
+            attempts = entry["attempts"] + 1
+            days = _backoff_days(attempts)
+            retry_after = (datetime.now(timezone.utc) + timedelta(days=days)).replace(microsecond=0).isoformat()
+            failures[song.url] = {"attempts": attempts, "retry_after": retry_after}
+            logger.info("[MISS] %s → no source found; backing off %d days (attempt %d)", _song_label(song), days, attempts)
+
+    if failures_file is not None:
+        _save_failures(failures_file, failures)
 
     # Only persist songs that were actually downloaded (path is not None).
     # Songs where spotdl returned None failed silently — exclude them from the snapshot

--- a/fetch/tests/test_spotdl_ops.py
+++ b/fetch/tests/test_spotdl_ops.py
@@ -321,6 +321,201 @@ def test_outcome_fail_logged_when_download_error(tmp_path: Path, caplog) -> None
     assert "[MISS]" not in caplog.text
 
 
+# ---------------------------------------------------------------------------
+# MISS backoff
+# ---------------------------------------------------------------------------
+
+
+def test_miss_track_written_to_failures_file(tmp_path: Path) -> None:
+    """A [MISS] track gets a backoff entry in the failures file."""
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    song = _make_mock_song("https://open.spotify.com/track/1", title="Missing", download_url=None)
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [song]
+    mock_spotdl.download_songs.return_value = [(song, None)]
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        sync_playlist(spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file)
+
+    assert failures_file.exists()
+    data = json.loads(failures_file.read_text(encoding="utf-8"))
+    assert song.url in data
+    assert data[song.url]["attempts"] == 1
+    assert "retry_after" in data[song.url]
+
+
+def test_fail_track_not_written_to_failures_file(tmp_path: Path) -> None:
+    """A [FAIL] track (download error, not a lookup failure) is not backed off."""
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    song = _make_mock_song("https://open.spotify.com/track/1", download_url="https://youtube.com/watch?v=x")
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [song]
+    mock_spotdl.download_songs.return_value = [(song, None)]
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        sync_playlist(spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file)
+
+    data = json.loads(failures_file.read_text(encoding="utf-8"))
+    assert song.url not in data
+
+
+def test_miss_track_in_backoff_is_skipped(tmp_path: Path) -> None:
+    """A [MISS] track whose retry_after is in the future is not attempted and doesn't consume budget."""
+    from datetime import datetime, timedelta, timezone
+
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    backed_off_url = "https://open.spotify.com/track/backed"
+    future = (datetime.now(timezone.utc) + timedelta(days=6)).replace(microsecond=0).isoformat()
+    failures_file.write_text(
+        json.dumps({backed_off_url: {"attempts": 1, "retry_after": future}}),
+        encoding="utf-8",
+    )
+
+    backed = _make_mock_song(backed_off_url, title="Backed Off")
+    fresh = _make_mock_song("https://open.spotify.com/track/fresh", title="Fresh")
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [backed, fresh]
+    mock_spotdl.download_songs.return_value = [(fresh, Path("/tmp/fresh.m4a"))]
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        _, tracks_sent = sync_playlist(
+            spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file,
+            failures_file=failures_file, track_limit=10,
+        )
+
+    # Only the fresh track should have been sent
+    assert tracks_sent == 1
+    downloaded = mock_spotdl.download_songs.call_args[0][0]
+    assert all(s.url != backed_off_url for s in downloaded)
+
+
+def test_miss_track_past_backoff_is_retried(tmp_path: Path) -> None:
+    """A [MISS] track whose retry_after has passed is attempted again."""
+    from datetime import datetime, timedelta, timezone
+
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    retry_url = "https://open.spotify.com/track/retry"
+    past = (datetime.now(timezone.utc) - timedelta(days=1)).replace(microsecond=0).isoformat()
+    failures_file.write_text(
+        json.dumps({retry_url: {"attempts": 1, "retry_after": past}}),
+        encoding="utf-8",
+    )
+
+    song = _make_mock_song(retry_url, title="Past Backoff", download_url=None)
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [song]
+    mock_spotdl.download_songs.return_value = [(song, None)]
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        _, tracks_sent = sync_playlist(
+            spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file,
+        )
+
+    assert tracks_sent == 1
+    data = json.loads(failures_file.read_text(encoding="utf-8"))
+    assert data[retry_url]["attempts"] == 2  # incremented
+
+
+def test_backoff_schedule() -> None:
+    """Backoff grows 7 → 14 → 28 → 28 days across repeated misses."""
+    from music_fetch.spotdl_ops import _backoff_days
+
+    assert _backoff_days(1) == 7
+    assert _backoff_days(2) == 14
+    assert _backoff_days(3) == 28
+    assert _backoff_days(4) == 28
+    assert _backoff_days(100) == 28
+
+
+def test_ok_track_removes_failures_entry(tmp_path: Path) -> None:
+    """A successful download clears the track's backoff entry."""
+    from datetime import datetime, timedelta, timezone
+
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+
+    track_url = "https://open.spotify.com/track/recovered"
+    past = (datetime.now(timezone.utc) - timedelta(days=1)).replace(microsecond=0).isoformat()
+    failures_file.write_text(
+        json.dumps({track_url: {"attempts": 2, "retry_after": past}}),
+        encoding="utf-8",
+    )
+
+    song = _make_mock_song(track_url, title="Recovered")
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [song]
+    mock_spotdl.download_songs.return_value = [(song, Path("/tmp/recovered.m4a"))]
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        sync_playlist(spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file)
+
+    data = json.loads(failures_file.read_text(encoding="utf-8"))
+    assert track_url not in data
+
+
+def test_removed_track_clears_failures_entry(tmp_path: Path) -> None:
+    """Tracks removed from the Spotify playlist are pruned from the failures file."""
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+
+    removed_url = "https://open.spotify.com/track/gone"
+    spotdl_file.write_text(
+        json.dumps({
+            "type": "sync",
+            "query": ["https://open.spotify.com/playlist/abc"],
+            "songs": [{"url": removed_url, "name": "Gone", "artists": []}],
+        }),
+        encoding="utf-8",
+    )
+    failures_file.write_text(
+        json.dumps({removed_url: {"attempts": 1, "retry_after": "2099-01-01T00:00:00+00:00"}}),
+        encoding="utf-8",
+    )
+
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = []  # track removed from Spotify
+    mock_spotdl.download_songs.return_value = []
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        sync_playlist(spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file)
+
+    data = json.loads(failures_file.read_text(encoding="utf-8"))
+    assert removed_url not in data
+
+
+def test_corrupt_failures_file_treated_as_empty(tmp_path: Path) -> None:
+    """A corrupt or unreadable failures file is handled gracefully — treated as empty."""
+    spotdl_file, output_dir, cookie_file = _setup_sync(tmp_path)
+    failures_file = tmp_path / ".spotdl-failures.json"
+    save_playlist(url="https://open.spotify.com/playlist/abc", spotdl_file=spotdl_file)
+    failures_file.write_text("not valid json", encoding="utf-8")
+
+    song = _make_mock_song("https://open.spotify.com/track/1", title="Normal")
+    mock_spotdl = mock.Mock()
+    mock_spotdl.search.return_value = [song]
+    mock_spotdl.download_songs.return_value = [(song, Path("/tmp/1.m4a"))]
+
+    with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
+        _, tracks_sent = sync_playlist(
+            spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file,
+        )
+
+    assert tracks_sent == 1  # proceeded normally despite corrupt file
+
+
 def test_outcome_defer_logged_for_budget_limited_tracks(tmp_path: Path, caplog) -> None:
     """[DEFER] is logged for tracks not attempted due to track budget."""
     import logging

--- a/justfile
+++ b/justfile
@@ -49,6 +49,14 @@ scan:
 sync:
     just fetch && just scan
 
+# Show tracks currently in MISS backoff (backed off after repeated 'no source found' failures)
+list-failures:
+    docker compose run --rm service sh -c "cat /root/Music/inbox/.spotdl-failures.json 2>/dev/null | python3 -m json.tool || echo '(no backoff state)'"
+
+# Clear all MISS backoff state — all tracks will be retried on the next run
+clear-failures:
+    docker compose run --rm service sh -c "rm -f /root/Music/inbox/.spotdl-failures.json && echo Cleared"
+
 # One-time migration: populate spotify_url flex attr for items imported before #100 fix.
 # Pass --dry-run to preview, --playlist <name> to limit to one playlist.
 backfill-spotify-urls *args:


### PR DESCRIPTION
Closes #102.

## Summary

- Tracks returning `[MISS]` (no YouTube source found) are now backed off exponentially: 7 → 14 → 28 days, repeating indefinitely at 28 days. They are filtered from `truly_new` **before** the budget is applied, so they no longer consume slots from `SYNC_TRACK_LIMIT`.
- `[FAIL]` tracks (source found, download error) are unchanged — still retried every night, as these are transient failures.
- Backoff state is persisted to `/root/Music/inbox/.spotdl-failures.json` (keyed by Spotify URL), so a track backed off on one playlist is also skipped on other playlists containing the same track.
- On success, a track's backoff entry is cleared automatically.
- Tracks removed from Spotify are pruned from the failures file.
- The failures file path is logged at startup for discoverability.

## New just recipes

- `just list-failures` — pretty-print current backoff state
- `just clear-failures` — reset all backoff (all tracks retried next run)

To unblock a single track before its window expires, delete its entry from `.spotdl-failures.json` directly.

## Test plan

- [x] All 77 existing tests pass
- [x] New tests cover: MISS written to file, FAIL not written, backed-off track skipped (no budget consumed), past-backoff track retried, backoff schedule (7/14/28), OK clears entry, Spotify removal prunes entry, corrupt file handled gracefully