### PR TITLE
fix: log beet stderr on import failure

### DIFF
--- a/scan/music_scan/process.py
+++ b/scan/music_scan/process.py
@@ -79,7 +79,17 @@ def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool =
     logger.debug("Running: %s", " ".join(cmd))
 
     log_start = IMPORT_LOG.stat().st_size if IMPORT_LOG.exists() else 0
-    proc = subprocess.Popen(cmd)
+    proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)
+
+    stderr_buf: list[bytes] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_buf.append(line)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
 
     stop = threading.Event()
     if skip_limit is not None:
@@ -93,9 +103,12 @@ def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool =
     with _forward_sigterm(proc):
         rc = proc.wait()
     stop.set()
+    stderr_thread.join()
 
     # rc=-15 (SIGTERM) is expected when skip_limit fires — not an error
     if rc not in (0, -15):
+        if stderr_buf:
+            logger.error("beet stderr:\n%s", b"".join(stderr_buf).decode(errors="replace"))
         raise subprocess.CalledProcessError(rc, cmd)
 
 


### PR DESCRIPTION
## Summary

- Pipes beet's stderr through a drain thread so it's captured rather than going to the container's inherited stderr
- Logs captured output at `ERROR` level before raising `CalledProcessError`, making failures diagnosable from Prefect flow logs without needing raw pod logs

Prompted by the cerise-hyena flow run failure (2026-05-15) where beet exited 1 but left no trace of why in the Prefect logs.

## Test plan
- [ ] All existing tests pass (`just test`)
- [ ] On next `beet import` failure, stderr appears in the Prefect task log

🤖 Generated with [Claude Code](https://claude.com/claude-code)