### PR TITLE
fix: ensure beet-import concurrency limit exists on startup

### DIFF
--- a/service/music_service/cli.py
+++ b/service/music_service/cli.py
@@ -48,7 +48,7 @@ def main() -> None:
     from music_service.api import create_app
     from music_service.debounce import Debouncer
     from music_service.flows import fetch_and_scan_flow, scan_flow
-    from music_service.prefect_client import trigger_scan
+    from music_service.prefect_client import ensure_concurrency_limits, trigger_scan
     import waitress
 
     fetch_cron = os.environ.get("FETCH_CRON", "0 3 * * *")
@@ -72,6 +72,8 @@ def main() -> None:
         cron=fetch_cron,
     )
     scan_deployment = scan_flow.to_deployment(name="scan")
+
+    ensure_concurrency_limits()
 
     logger.info("Starting Prefect runner (FETCH_CRON=%s)", fetch_cron)
     try:

--- a/service/music_service/prefect_client.py
+++ b/service/music_service/prefect_client.py
@@ -115,3 +115,27 @@ def trigger_scan() -> None:
             logger.error("Failed to submit scan: %s", exc)
     else:
         _direct(_run_scan)
+
+
+async def _upsert_limits() -> None:
+    from prefect import get_client
+    async with get_client() as client:
+        await client.upsert_global_concurrency_limit_by_name(
+            name="beet-import",
+            limit=1,
+        )
+
+
+def ensure_concurrency_limits() -> None:
+    """Create/update Prefect global concurrency limits required by the flows.
+
+    No-op when PREFECT_API_URL is not set (direct/test mode uses a threading
+    lock instead).
+    """
+    if not _has_server():
+        return
+    try:
+        asyncio.run(_upsert_limits())
+        logger.info("Prefect concurrency limit 'beet-import' ensured (limit=1)")
+    except Exception as exc:
+        logger.warning("Could not upsert Prefect concurrency limit: %s", exc)


### PR DESCRIPTION
Creates/upserts the Prefect global concurrency limit at service start so two concurrent scan flows can't both acquire it and race on library.db.