### PR TITLE
fix: decouple fetch/scan flows, inject AcoustID via ENV, surface beet stderr

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,2 +1,3 @@
 SPOTIFY_CLIENT_ID=op://Personal/Spotify API/username
 SPOTIFY_CLIENT_SECRET=op://Personal/Spotify API/credential
+ACOUSTID_APIKEY=op://Personal/AcoustID API/credential

--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 SPOTDL_DIR = Path("/root/Music/inbox/spotdl")
 FAILURES_FILE = SPOTDL_DIR.parent / ".spotdl-failures.json"
+PENDING_REMOVALS_PATH = SPOTDL_DIR.parent / ".pending-removals.json"
 COOKIE_FILE = Path("/root/.config/spotdl/cookies.txt")
 CONF_PATH = Path("/root/.config/music-pipeline/playlists.conf")
 
@@ -304,6 +305,38 @@ def sync_playlists(
 
     logger.info("==> music-ingest complete. Run music-scan for local import and playlist generation.")
     return PendingRemovals(tracks=pending_removals, remove_sources=remove_sources)
+
+
+def save_pending_removals(pending: PendingRemovals) -> None:
+    """Write pending removals to the shared handoff file for music-scan to read."""
+    if not pending.tracks and not pending.remove_sources:
+        return
+    data = {
+        "tracks": [dataclasses.asdict(t) for t in pending.tracks],
+        "remove_sources": pending.remove_sources,
+    }
+    PENDING_REMOVALS_PATH.write_text(json.dumps(data), encoding="utf-8")
+    logger.info(
+        "Saved %d track removal(s) and %d source removal(s) to %s",
+        len(pending.tracks),
+        len(pending.remove_sources),
+        PENDING_REMOVALS_PATH,
+    )
+
+
+def load_and_clear_pending_removals() -> PendingRemovals | None:
+    """Read and delete the pending-removals handoff file. Returns None if absent."""
+    if not PENDING_REMOVALS_PATH.exists():
+        return None
+    try:
+        data = json.loads(PENDING_REMOVALS_PATH.read_text(encoding="utf-8"))
+        tracks = [RemovedTrack(**t) for t in data.get("tracks", [])]
+        return PendingRemovals(tracks=tracks, remove_sources=data.get("remove_sources", []))
+    except Exception:
+        logger.warning("Failed to load %s — skipping pending removals", PENDING_REMOVALS_PATH, exc_info=True)
+        return None
+    finally:
+        PENDING_REMOVALS_PATH.unlink(missing_ok=True)
 
 
 def run() -> PendingRemovals:

--- a/justfile
+++ b/justfile
@@ -64,6 +64,11 @@ backfill-spotify-urls *args:
         --volume {{justfile_directory()}}/scripts/backfill-spotify-urls.py:/tmp/backfill-spotify-urls.py \
         service python3 /tmp/backfill-spotify-urls.py {{args}}
 
+# Fingerprint all beets items lacking mb_trackid via AcoustID. Requires ACOUSTID_APIKEY env var.
+# Safe to re-run: skips items that already have mb_trackid.
+mb-fingerprint:
+    op run --env-file .env.tpl -- docker compose run --rm service music-mb-fingerprint
+
 # Dump beets DB and export JSON from the container
 backup:
     docker compose run --rm service sh -c "beet export > /root/.config/beets/library-export.json"

--- a/scan/music_scan/mb_fingerprint.py
+++ b/scan/music_scan/mb_fingerprint.py
@@ -17,8 +17,25 @@ import time
 logger = logging.getLogger(__name__)
 
 LIBRARY_DB = "/root/.config/beets/library.db"
+LIBRARY_DIR = "/root/Music/library"
 MIN_SCORE = 0.85
 REQUEST_DELAY = 0.35
+
+
+def _resolve_path(raw: str) -> str:
+    """Return the filesystem path for a beets item path.
+
+    Handles the case where the beets DB recorded paths under /root/Music/ but
+    the files were later moved/placed under /root/Music/library/.
+    """
+    import os
+    if os.path.exists(raw):
+        return raw
+    # Try inserting library/ after /root/Music/
+    alt = raw.replace("/root/Music/", "/root/Music/library/", 1)
+    if os.path.exists(alt):
+        return alt
+    return raw  # return original so the error message is meaningful
 
 
 def run(library_db: str = LIBRARY_DB) -> None:
@@ -37,7 +54,8 @@ def run(library_db: str = LIBRARY_DB) -> None:
 
         tagged = no_match = errors = 0
         for n, item in enumerate(items, 1):
-            path = item.path.decode() if isinstance(item.path, bytes) else item.path
+            raw = item.path.decode() if isinstance(item.path, bytes) else item.path
+            path = _resolve_path(raw)
             label = f"{item.artist or item.albumartist or '?'} – {item.title or '?'}"
             try:
                 results = list(acoustid.match(api_key, path))

--- a/scan/music_scan/mb_fingerprint.py
+++ b/scan/music_scan/mb_fingerprint.py
@@ -22,23 +22,7 @@ MIN_SCORE = 0.85
 REQUEST_DELAY = 0.35
 
 
-def _resolve_path(raw: str) -> str:
-    """Return the filesystem path for a beets item path.
-
-    Handles the case where the beets DB recorded paths under /root/Music/ but
-    the files were later moved/placed under /root/Music/library/.
-    """
-    import os
-    if os.path.exists(raw):
-        return raw
-    # Try inserting library/ after /root/Music/
-    alt = raw.replace("/root/Music/", "/root/Music/library/", 1)
-    if os.path.exists(alt):
-        return alt
-    return raw  # return original so the error message is meaningful
-
-
-def run(library_db: str = LIBRARY_DB) -> None:
+def run(library_db: str = LIBRARY_DB, library_dir: str = LIBRARY_DIR) -> None:
     import acoustid
     import beets.library
 
@@ -46,7 +30,8 @@ def run(library_db: str = LIBRARY_DB) -> None:
     if not api_key:
         raise RuntimeError("ACOUSTID_APIKEY env var is not set")
 
-    lib = beets.library.Library(library_db)
+    # directory must be passed explicitly — without it Library defaults to ~/Music
+    lib = beets.library.Library(library_db, directory=library_dir)
     try:
         items = [i for i in lib.items() if not i.mb_trackid]
         total = len(items)
@@ -54,8 +39,7 @@ def run(library_db: str = LIBRARY_DB) -> None:
 
         tagged = no_match = errors = 0
         for n, item in enumerate(items, 1):
-            raw = item.path.decode() if isinstance(item.path, bytes) else item.path
-            path = _resolve_path(raw)
+            path = item.path.decode() if isinstance(item.path, bytes) else item.path
             label = f"{item.artist or item.albumartist or '?'} – {item.title or '?'}"
             try:
                 results = list(acoustid.match(api_key, path))

--- a/scan/music_scan/mb_fingerprint.py
+++ b/scan/music_scan/mb_fingerprint.py
@@ -1,0 +1,72 @@
+"""music-mb-fingerprint: add mb_trackid to beets items that lack one.
+
+Fingerprints each file via AcoustID and writes mb_trackid back to the
+beets library where a confident match (>= 0.85) is found. No other
+metadata is changed.
+
+Requires ACOUSTID_APIKEY env var. Safe to re-run: skips items that
+already have mb_trackid.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+LIBRARY_DB = "/root/.config/beets/library.db"
+MIN_SCORE = 0.85
+REQUEST_DELAY = 0.35
+
+
+def run(library_db: str = LIBRARY_DB) -> None:
+    import acoustid
+    import beets.library
+
+    api_key = os.environ.get("ACOUSTID_APIKEY")
+    if not api_key:
+        raise RuntimeError("ACOUSTID_APIKEY env var is not set")
+
+    lib = beets.library.Library(library_db)
+    try:
+        items = [i for i in lib.items() if not i.mb_trackid]
+        total = len(items)
+        logger.info("Fingerprinting %d item(s) without mb_trackid", total)
+
+        tagged = no_match = errors = 0
+        for n, item in enumerate(items, 1):
+            path = item.path.decode() if isinstance(item.path, bytes) else item.path
+            label = f"{item.artist or item.albumartist or '?'} – {item.title or '?'}"
+            try:
+                results = list(acoustid.match(api_key, path))
+                if results:
+                    score, rec_id, *_ = results[0]
+                    if score >= MIN_SCORE and rec_id:
+                        item.mb_trackid = rec_id
+                        item.store()
+                        logger.info("[%d/%d] %s -> %s (%.2f)", n, total, label, rec_id, score)
+                        tagged += 1
+                        continue
+                    logger.info("[%d/%d] %s: low confidence (%.2f)", n, total, label, score)
+                else:
+                    logger.info("[%d/%d] %s: no results", n, total, label)
+                no_match += 1
+            except Exception as exc:
+                logger.warning("[%d/%d] %s: %s", n, total, label, exc)
+                errors += 1
+            time.sleep(REQUEST_DELAY)
+    finally:
+        lib._close()
+
+    logger.info(
+        "Done: %d tagged, %d no confident match, %d errors",
+        tagged, no_match, errors,
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(message)s",
+                        datefmt="%Y-%m-%dT%H:%M:%S%z")
+    run()

--- a/scan/music_scan/process.py
+++ b/scan/music_scan/process.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import subprocess
 import threading
@@ -14,6 +15,24 @@ from typing import Generator
 logger = logging.getLogger(__name__)
 
 IMPORT_LOG = Path("/root/.config/beets/import.log")
+_ACOUSTID_CONFIG = Path("/tmp/beets-acoustid.yaml")
+_acoustid_config_written = False
+
+
+def _extra_beet_args() -> list[str]:
+    """Return [-c, path] args for beet if ACOUSTID_APIKEY is set, else [].
+
+    Writes a supplementary beets config with the AcoustID key on first call so
+    the key never has to be embedded in the ConfigMap.
+    """
+    global _acoustid_config_written
+    key = os.environ.get("ACOUSTID_APIKEY")
+    if not key:
+        return []
+    if not _acoustid_config_written:
+        _ACOUSTID_CONFIG.write_text(f"acoustid:\n  apikey: {key}\n", encoding="utf-8")
+        _acoustid_config_written = True
+    return ["-c", str(_ACOUSTID_CONFIG)]
 
 
 @contextmanager
@@ -72,7 +91,7 @@ def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool =
         asis: If True, pass ``--asis`` to import using existing embedded tags without
               MusicBrainz lookups.
     """
-    cmd = ["beet", "import", "--quiet"]
+    cmd = ["beet"] + _extra_beet_args() + ["import", "--quiet"]
     if asis:
         cmd.append("-A")
     cmd.append(str(inbox_dir))
@@ -81,14 +100,14 @@ def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool =
     log_start = IMPORT_LOG.stat().st_size if IMPORT_LOG.exists() else 0
     proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)
 
-    stderr_buf: list[bytes] = []
-
-    def _drain_stderr() -> None:
+    def _stream_stderr() -> None:
         assert proc.stderr is not None
         for line in proc.stderr:
-            stderr_buf.append(line)
+            text = line.decode(errors="replace").rstrip()
+            if text:
+                logger.warning("beet: %s", text)
 
-    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread = threading.Thread(target=_stream_stderr, daemon=True)
     stderr_thread.start()
 
     stop = threading.Event()
@@ -107,13 +126,11 @@ def run_beet_import(inbox_dir: Path, skip_limit: int | None = None, asis: bool =
 
     # rc=-15 (SIGTERM) is expected when skip_limit fires — not an error
     if rc not in (0, -15):
-        if stderr_buf:
-            logger.error("beet stderr:\n%s", b"".join(stderr_buf).decode(errors="replace"))
         raise subprocess.CalledProcessError(rc, cmd)
 
 
 def run_beet_update() -> None:
     """Run ``beet update`` (non-fatal on failure)."""
-    result = subprocess.run(["beet", "update"], check=False)
+    result = subprocess.run(["beet"] + _extra_beet_args() + ["update"], check=False)
     if result.returncode != 0:
         logger.warning("beet update exited with code %d (non-fatal)", result.returncode)

--- a/scan/music_scan/scan.py
+++ b/scan/music_scan/scan.py
@@ -96,6 +96,12 @@ def run_inbox_import(skip_limit: int | None = None) -> list[tuple[str, str]]:
     with MusicLibrary(LIBRARY_DB) as lib:
         imported = lib.items_added_since(import_start)
     logger.info("Newly imported : %d track(s)", len(imported))
+    if inbox_snapshot and not imported:
+        logger.warning(
+            "==> 0 of %d inbox file(s) were imported — beets skipped all tracks. "
+            "Check ~/.config/beets/import.log for skip details.",
+            len(inbox_snapshot),
+        )
     _check_import_names(inbox_snapshot, imported)
     return imported
 

--- a/scan/pyproject.toml
+++ b/scan/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = ["music-pipeline-fetch"]
 
 [project.scripts]
 music-scan = "music_scan.cli:main"
+music-mb-fingerprint = "music_scan.mb_fingerprint:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/service/music_service/flows.py
+++ b/service/music_service/flows.py
@@ -94,10 +94,26 @@ def spotdl_sync_task(remove_sources: list[str]):
 # ---------------------------------------------------------------------------
 
 
+@task(name="save-removals", log_prints=True)
+def save_removals_task(pending) -> None:
+    """Persist pending removals to disk for the scan flow to consume."""
+    logger = get_run_logger()
+    if pending.tracks or pending.remove_sources:
+        ingest.save_pending_removals(pending)
+        logger.info(
+            "Saved %d track removal(s), %d source removal(s)",
+            len(pending.tracks),
+            len(pending.remove_sources),
+        )
+    else:
+        logger.info("No pending removals")
+
+
 @task(name="apply-removals", log_prints=True)
-def apply_removals_task(pending=None) -> None:
+def apply_removals_task() -> None:
     """Clear beets source tags for tracks removed from Spotify playlists."""
     logger = get_run_logger()
+    pending = ingest.load_and_clear_pending_removals()
     if pending is None:
         logger.info("No pending removals")
         return
@@ -195,23 +211,17 @@ def reconcile_task() -> None:
 
 @flow(name="fetch-and-scan", log_prints=True)
 def fetch_and_scan_flow() -> None:
-    """Full pipeline: spotdl fetch then beets scan."""
+    """Fetch only: spotdl sync. Scan is triggered separately by the file watcher."""
     preflight_task()
     remove_sources = reconcile_playlists_task()
     pending = spotdl_sync_task(remove_sources)
-    apply_removals_task(pending)
-    beet_import_task()
-    quarantine_task()
-    asis_import_task()
-    beet_update_task()
-    regen_playlists_task()
-    navidrome_task()
-    reconcile_task()
+    save_removals_task(pending)
 
 
 @flow(name="scan", log_prints=True)
 def scan_flow() -> None:
-    """Scan only: import inbox and regenerate playlists."""
+    """Scan: apply any pending removals, import inbox, regenerate playlists."""
+    apply_removals_task()
     beet_import_task()
     quarantine_task()
     asis_import_task()

--- a/service/music_service/prefect_client.py
+++ b/service/music_service/prefect_client.py
@@ -48,27 +48,25 @@ def _via_api(deployment_name: str) -> bool:
 
 def _run_fetch_and_scan() -> None:
     import music_fetch.ingest as ingest
-    import music_scan.reconcile as reconcile
-    import music_scan.scan as scan
     try:
         logger.info("==> Fetch starting")
         pending = ingest.run()
-        logger.info("==> Scan starting")
-        scan.run(pending)
-        reconcile.reconcile_all()
-        logger.info("==> Scan complete")
+        ingest.save_pending_removals(pending)
+        logger.info("==> Fetch complete")
     except Exception:
-        logger.exception("fetch-and-scan failed")
+        logger.exception("fetch failed")
     finally:
         _lock.release()
 
 
 def _run_scan() -> None:
+    import music_fetch.ingest as ingest
     import music_scan.reconcile as reconcile
     import music_scan.scan as scan
     try:
         logger.info("==> Scan starting")
-        scan.run(None)
+        pending = ingest.load_and_clear_pending_removals()
+        scan.run(pending)
         reconcile.reconcile_all()
         logger.info("==> Scan complete")
     except Exception:

--- a/service/tests/test_flows.py
+++ b/service/tests/test_flows.py
@@ -74,10 +74,32 @@ def test_spotdl_sync_task_pushes_metrics_on_failure():
 # ---------------------------------------------------------------------------
 
 
-def test_apply_removals_task_skips_when_none():
+def test_save_removals_task_skips_when_empty():
+    from music_service.flows import save_removals_task
+    mock_pending = MagicMock()
+    mock_pending.tracks = []
+    mock_pending.remove_sources = []
+    with patch("music_service.flows.ingest") as mock_ingest:
+        save_removals_task(mock_pending)
+        mock_ingest.save_pending_removals.assert_not_called()
+
+
+def test_save_removals_task_writes_when_non_empty():
+    from music_service.flows import save_removals_task
+    mock_pending = MagicMock()
+    mock_pending.tracks = [MagicMock()]
+    mock_pending.remove_sources = []
+    with patch("music_service.flows.ingest") as mock_ingest:
+        save_removals_task(mock_pending)
+        mock_ingest.save_pending_removals.assert_called_once_with(mock_pending)
+
+
+def test_apply_removals_task_skips_when_no_file():
     from music_service.flows import apply_removals_task
-    with patch("music_service.flows.scan") as mock_scan:
-        apply_removals_task(None)
+    with patch("music_service.flows.ingest") as mock_ingest, \
+         patch("music_service.flows.scan") as mock_scan:
+        mock_ingest.load_and_clear_pending_removals.return_value = None
+        apply_removals_task()
         mock_scan.apply_pending_removals.assert_not_called()
 
 
@@ -85,11 +107,13 @@ def test_apply_removals_task_calls_apply_pending_removals():
     from music_service.flows import apply_removals_task
     mock_pending = MagicMock()
     mock_lib = MagicMock()
-    with patch("music_service.flows.scan") as mock_scan, \
+    with patch("music_service.flows.ingest") as mock_ingest, \
+         patch("music_service.flows.scan") as mock_scan, \
          patch("music_scan.library.MusicLibrary") as MockLib:
+        mock_ingest.load_and_clear_pending_removals.return_value = mock_pending
         MockLib.return_value.__enter__ = lambda _: mock_lib
         MockLib.return_value.__exit__ = MagicMock(return_value=False)
-        apply_removals_task(mock_pending)
+        apply_removals_task()
         mock_scan.apply_pending_removals.assert_called_once()
 
 
@@ -139,44 +163,51 @@ def test_reconcile_task_calls_reconcile_all():
 # ---------------------------------------------------------------------------
 
 
-def test_fetch_and_scan_flow_runs_all_steps_in_order():
+def test_fetch_and_scan_flow_runs_fetch_steps_only():
     from music_service.flows import fetch_and_scan_flow
     call_order: list[str] = []
     mock_pending = MagicMock()
+    mock_pending.tracks = []
+    mock_pending.remove_sources = []
     mock_metrics = MagicMock()
 
     with patch("music_service.flows.ingest") as mock_ingest, \
          patch("music_service.flows.scan") as mock_scan, \
-         patch("music_service.flows.reconcile") as mock_reconcile, \
-         patch("music_service.flows.concurrency") as mock_concurrency, \
          patch("music_service.flows.IngestMetrics", return_value=mock_metrics):
-        mock_concurrency.return_value.__enter__.return_value = None
-        mock_concurrency.return_value.__exit__.return_value = False
         mock_ingest.preflight.side_effect = lambda: call_order.append("preflight")
         mock_ingest.reconcile_playlists.side_effect = lambda: (call_order.append("reconcile-playlists"), [])[1]
         mock_ingest.sync_playlists.side_effect = lambda *_: (call_order.append("spotdl-sync"), mock_pending)[1]
-        mock_scan.apply_pending_removals.side_effect = lambda *_: (call_order.append("apply-removals"), 0)[1]
+
+        fetch_and_scan_flow()
+
+    assert call_order == ["preflight", "reconcile-playlists", "spotdl-sync"]
+    mock_scan.run_inbox_import.assert_not_called()
+
+
+def test_scan_flow_runs_all_scan_steps_in_order():
+    from music_service.flows import scan_flow
+    call_order: list[str] = []
+
+    with patch("music_service.flows.ingest") as mock_ingest, \
+         patch("music_service.flows.scan") as mock_scan, \
+         patch("music_service.flows.reconcile") as mock_reconcile, \
+         patch("music_service.flows.concurrency") as mock_concurrency:
+        mock_concurrency.return_value.__enter__.return_value = None
+        mock_concurrency.return_value.__exit__.return_value = False
+        mock_ingest.load_and_clear_pending_removals.return_value = None
         mock_scan.run_inbox_import.side_effect = lambda: (call_order.append("beet-import"), [])[1]
         mock_scan.quarantine_inbox_leftovers.side_effect = lambda: (call_order.append("quarantine"), 0)[1]
         mock_scan.import_asis_from_quarantine.side_effect = lambda: (call_order.append("asis-import"), 0)[1]
         mock_scan.regen_playlists.side_effect = lambda: (call_order.append("regen-playlists"), {})[1]
         mock_reconcile.reconcile_all.side_effect = lambda: (call_order.append("reconcile-snapshots"), 0)[1]
 
-        with patch("music_scan.library.MusicLibrary") as MockLib, \
-             patch("music_scan.process.run_beet_update") as mock_update, \
+        with patch("music_scan.process.run_beet_update") as mock_update, \
              patch("music_scan.navidrome.trigger_scan") as mock_navidrome:
-            MockLib.return_value.__enter__ = lambda _: MagicMock()
-            MockLib.return_value.__exit__ = MagicMock(return_value=False)
             mock_update.side_effect = lambda: call_order.append("beet-update")
             mock_navidrome.side_effect = lambda: call_order.append("navidrome")
-
-            fetch_and_scan_flow()
+            scan_flow()
 
     assert call_order == [
-        "preflight",
-        "reconcile-playlists",
-        "spotdl-sync",
-        "apply-removals",
         "beet-import",
         "quarantine",
         "asis-import",
@@ -185,24 +216,5 @@ def test_fetch_and_scan_flow_runs_all_steps_in_order():
         "navidrome",
         "reconcile-snapshots",
     ]
-
-
-def test_scan_flow_skips_fetch_tasks():
-    from music_service.flows import scan_flow
-    with patch("music_service.flows.ingest") as mock_ingest, \
-         patch("music_service.flows.scan") as mock_scan, \
-         patch("music_service.flows.reconcile") as mock_reconcile, \
-         patch("music_service.flows.concurrency") as mock_concurrency:
-        mock_concurrency.return_value.__enter__.return_value = None
-        mock_concurrency.return_value.__exit__.return_value = False
-        mock_scan.run_inbox_import.return_value = []
-        mock_scan.quarantine_inbox_leftovers.return_value = 0
-        mock_scan.import_asis_from_quarantine.return_value = 0
-        mock_reconcile.reconcile_all.return_value = 0
-        with patch("music_scan.process.run_beet_update"), \
-             patch("music_scan.navidrome.trigger_scan"):
-            scan_flow()
-        mock_ingest.preflight.assert_not_called()
-        mock_ingest.reconcile_playlists.assert_not_called()
-        mock_ingest.sync_playlists.assert_not_called()
-        mock_scan.run_inbox_import.assert_called_once()
+    mock_ingest.preflight.assert_not_called()
+    mock_ingest.sync_playlists.assert_not_called()


### PR DESCRIPTION
## Summary

- **Decouple fetch and scan flows (Option A)**: Strip scan steps from `fetch-and-scan`; it now only runs spotdl sync and saves pending removals to `.pending-removals.json` on the shared PVC. The watchdog-triggered `scan` flow reads and clears the file, then runs the full beet pipeline. Eliminates the race condition where the file watcher fired a concurrent scan mid-fetch.
- **AcoustID API key via ENV**: `ACOUSTID_APIKEY` env var is now injected into beet subprocesses via a supplementary config file (`/tmp/beets-acoustid.yaml`). Previously the key was never passed to beet, causing silent fallback to title-only MusicBrainz search which failed at `strong_rec_thresh: 0.10`.
- **Stream beet stderr to logs in real-time**: `run_beet_import` now logs each beet stderr line as `WARNING` as it arrives, instead of buffering and discarding on success. Adds a warning when 0 of N inbox files are imported (beet doesn't warn about a missing AcoustID key itself).
- **`music-mb-fingerprint` CLI**: New entry point to backfill `mb_trackid` on all beets library items that lack one, using AcoustID fingerprinting. Safe to re-run (skips already-tagged items). Requires `ACOUSTID_APIKEY` env var.

## Test plan

- [ ] `just test` passes (all suites)
- [ ] Deploy new images to cluster
- [ ] Verify `ACOUSTID_APIKEY` is mounted in the scan container from `music-pipeline-credentials` secret
- [ ] Run a fetch+scan cycle and confirm beet no longer skips all tracks
- [ ] Run `music-mb-fingerprint` in the scan pod to backfill the ~379 library items missing `mb_trackid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)