### PR TITLE
fix(beets): replace deprecated source_weight with data_source_mismatch_penalty

### DIFF
--- a/config/beets/integration-test-config.yaml
+++ b/config/beets/integration-test-config.yaml
@@ -29,7 +29,7 @@ musicbrainz:
   # spotdl files have data_source=None; without this, every MusicBrainz/
   # AcoustID candidate gets +0.5 added to its distance, pushing all matches
   # above the strong_rec_thresh and causing quiet-mode to skip everything.
-  source_weight: 0.0
+  data_source_mismatch_penalty: 0.0
 
 paths:
   default: $albumartist/$album/$track - $title

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ SERVICE_IMAGE = os.environ.get(
 )
 
 REPO_ROOT = Path(__file__).parent.parent
-BEETS_CONFIG = str(REPO_ROOT / "config" / "beets" / "config.yaml")
+BEETS_CONFIG = str(REPO_ROOT / "config" / "beets" / "integration-test-config.yaml")
 SPOTDL_CONFIG = str(REPO_ROOT / "config" / "spotdl" / "config.json")
 PLAYLISTS_CONF = str(REPO_ROOT / "config" / "playlists.conf")
 COOKIES_PATH = REPO_ROOT / "cookies.txt"


### PR DESCRIPTION
## Summary

- Replaces deprecated `musicbrainz.source_weight` with `musicbrainz.data_source_mismatch_penalty` (renamed in beets 2.11.0)
- Renames `config/beets/config.yaml` → `config/beets/integration-test-config.yaml` to make clear this file is only used by the test harness, not the running service

## Why it was failing

beets 2.11.0 emits a deprecation warning to stdout when the old `source_weight` key is used. `test_duplicate_import_skipped` calls `beet ls` and counts output lines, expecting exactly 1 (the track). The warning appeared as a second line, causing `assert 2 == 1`.

## Related

Fixes the CI failure on d965cb5 (which was also incorrectly committed directly to trunk — this PR is the correct fix via branch + PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)