### PR TITLE
fix(fetch): distinguish tracks attempted from tracks downloaded

### DIFF
--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -276,7 +276,7 @@ def sync_playlists(
         output_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            removed_urls, tracks_sent = sync_playlist(
+            removed_urls, attempted, downloaded = sync_playlist(
                 spotdl_file=spotdl_file,
                 output_dir=output_dir,
                 cookie_file=COOKIE_FILE,
@@ -294,9 +294,11 @@ def sync_playlists(
                 metrics.cookies_expired = True
             raise
 
-        metrics.tracks_downloaded += tracks_sent
+        metrics.tracks_attempted += attempted
+        metrics.tracks_downloaded += downloaded
         if remaining is not None:
-            remaining -= tracks_sent
+            # Budget is consumed per attempt: a stuck [MISS] cluster would otherwise loop forever.
+            remaining -= attempted
 
         _collect_removals(pending_removals, removed_urls, old_songs, name)
 

--- a/fetch/music_fetch/metrics.py
+++ b/fetch/music_fetch/metrics.py
@@ -38,6 +38,7 @@ class IngestMetrics:
     playlists_total: int = 0
     playlists_skipped: int = 0
     playlists_deferred: int = 0
+    tracks_attempted: int = 0
     tracks_downloaded: int = 0
     cookies_expired: bool = False
     failure_reason: str = ""
@@ -49,6 +50,7 @@ class IngestMetrics:
             _gauge("music_ingest_playlists_total", self.playlists_total),
             _gauge("music_ingest_playlists_skipped_total", self.playlists_skipped),
             _gauge("music_ingest_playlists_deferred_total", self.playlists_deferred),
+            _gauge("music_ingest_tracks_attempted_total", self.tracks_attempted),
             _gauge("music_ingest_tracks_downloaded_total", self.tracks_downloaded),
             _gauge("music_ingest_cookies_expired", int(self.cookies_expired)),
         ]

--- a/fetch/music_fetch/spotdl_ops.py
+++ b/fetch/music_fetch/spotdl_ops.py
@@ -123,7 +123,7 @@ def sync_playlist(
     cookie_file: Path,
     track_limit: int | None = None,
     failures_file: Path | None = None,
-) -> tuple[set[str], int]:
+) -> tuple[set[str], int, int]:
     """Sync a playlist from its .spotdl file.
 
     Downloads tracks new to the Spotify playlist, up to *track_limit* new
@@ -136,8 +136,9 @@ def sync_playlist(
 
     Returns a tuple of:
       - the set of Spotify track URLs removed from the playlist since the last sync
-      - the number of tracks sent to spotdl this session (tracks *sent*, not confirmed
-        completions — spotdl may download fewer if some are unavailable on YouTube)
+      - the number of tracks sent to spotdl this session (tracks *attempted*; budget
+        is consumed per attempt so a stuck [MISS] doesn't loop forever)
+      - the number of tracks spotdl actually wrote to disk (path is not None)
 
     Note on ordering: when *track_limit* is set, the batch is taken from the front of
     the list returned by spotdl.search(), which for Spotify playlists is typically
@@ -251,7 +252,7 @@ def sync_playlist(
             ensure_ascii=False,
         )
 
-    return removed_urls, len(truly_new)
+    return removed_urls, len(truly_new), len(downloaded_urls)
 
 
 def find_track_in_snapshot(snapshot: list[dict], url: str) -> dict | None:

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -304,6 +304,7 @@ def test_run_reconcile_failure_sets_reconcile_error_reason(tmp_path: Path) -> No
         def __init__(self):
             self.success = True
             self.failure_reason = ""
+            self.tracks_attempted = 0
             self.tracks_downloaded = 0
             self.playlists_total = 0
             self.playlists_skipped = 0

--- a/fetch/tests/test_metrics.py
+++ b/fetch/tests/test_metrics.py
@@ -88,6 +88,19 @@ def test_ingest_metrics_tracks_downloaded(monkeypatch: pytest.MonkeyPatch) -> No
     assert "music_ingest_tracks_downloaded_total 42" in pushed[0]
 
 
+def test_ingest_metrics_tracks_attempted_distinct_from_downloaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Attempted and downloaded are pushed as separate gauges so a 0-download night
+    is visibly distinct from an idle one (regression for issue #124)."""
+    pushed: list[str] = []
+    monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))
+
+    m = IngestMetrics(tracks_attempted=4, tracks_downloaded=0)
+    m.push()
+
+    assert "music_ingest_tracks_attempted_total 4" in pushed[0]
+    assert "music_ingest_tracks_downloaded_total 0" in pushed[0]
+
+
 def test_ingest_metrics_cookies_expired_true(monkeypatch: pytest.MonkeyPatch) -> None:
     pushed: list[str] = []
     monkeypatch.setattr("music_fetch.metrics._push", lambda body, job: pushed.append(body))

--- a/fetch/tests/test_spotdl_ops.py
+++ b/fetch/tests/test_spotdl_ops.py
@@ -75,17 +75,18 @@ def test_sync_playlist_after_stub_downloads_all_songs(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(s, Path(f"/tmp/{i}.m4a")) for i, s in enumerate(songs)]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, tracks_sent = sync_playlist(
+        removed_urls, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
         )
 
     # All 5 songs should be sent to download — none were in the empty snapshot
-    assert tracks_sent == 5
+    assert attempted == 5
+    assert downloaded == 5
     mock_spotdl.download_songs.assert_called_once()
-    downloaded = mock_spotdl.download_songs.call_args[0][0]
-    assert len(downloaded) == 5
+    sent_to_spotdl = mock_spotdl.download_songs.call_args[0][0]
+    assert len(sent_to_spotdl) == 5
     assert removed_urls == set()
 
     # All 5 downloaded songs should be persisted to the snapshot
@@ -120,17 +121,18 @@ def test_sync_playlist_second_run_skips_known_songs(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(s, Path(f"/tmp/{i}.m4a")) for i, s in enumerate(new_only)]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, tracks_sent = sync_playlist(
+        removed_urls, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
         )
 
     # Only the 2 new songs should be downloaded
-    assert tracks_sent == 2
-    downloaded = mock_spotdl.download_songs.call_args[0][0]
-    downloaded_urls = {s.url for s in downloaded}
-    assert downloaded_urls == {
+    assert attempted == 2
+    assert downloaded == 2
+    sent_to_spotdl = mock_spotdl.download_songs.call_args[0][0]
+    sent_urls = {s.url for s in sent_to_spotdl}
+    assert sent_urls == {
         "https://open.spotify.com/track/3",
         "https://open.spotify.com/track/4",
     }
@@ -166,14 +168,15 @@ def test_sync_playlist_detects_removed_tracks(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = []  # nothing new to download
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, tracks_sent = sync_playlist(
+        removed_urls, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
         )
 
     assert removed_urls == {"https://open.spotify.com/track/B"}
-    assert tracks_sent == 0  # A was already known; nothing new to download
+    assert attempted == 0  # A was already known; nothing new to download
+    assert downloaded == 0
 
 def test_sync_playlist_failed_downloads_not_persisted(tmp_path: Path) -> None:
     """Songs spotdl failed to download (path=None) are excluded from the snapshot.
@@ -201,13 +204,14 @@ def test_sync_playlist_failed_downloads_not_persisted(tmp_path: Path) -> None:
     ]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, tracks_sent = sync_playlist(
+        removed_urls, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
         )
 
-    assert tracks_sent == 4  # all 4 were sent to spotdl
+    assert attempted == 4  # all 4 were sent to spotdl
+    assert downloaded == 2  # only 2 actually landed on disk (regression for issue #124)
     assert removed_urls == set()
 
     # Only the 2 successful downloads should be in the snapshot
@@ -387,15 +391,16 @@ def test_miss_track_in_backoff_is_skipped(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(fresh, Path("/tmp/fresh.m4a"))]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        _, tracks_sent = sync_playlist(
+        _, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file,
             failures_file=failures_file, track_limit=10,
         )
 
     # Only the fresh track should have been sent
-    assert tracks_sent == 1
-    downloaded = mock_spotdl.download_songs.call_args[0][0]
-    assert all(s.url != backed_off_url for s in downloaded)
+    assert attempted == 1
+    assert downloaded == 1
+    sent_to_spotdl = mock_spotdl.download_songs.call_args[0][0]
+    assert all(s.url != backed_off_url for s in sent_to_spotdl)
 
 
 def test_miss_track_past_backoff_is_retried(tmp_path: Path) -> None:
@@ -419,11 +424,12 @@ def test_miss_track_past_backoff_is_retried(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(song, None)]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        _, tracks_sent = sync_playlist(
+        _, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file,
         )
 
-    assert tracks_sent == 1
+    assert attempted == 1
+    assert downloaded == 0  # spotdl returned path=None — must NOT be counted as downloaded
     data = json.loads(failures_file.read_text(encoding="utf-8"))
     assert data[retry_url]["attempts"] == 2  # incremented
 
@@ -509,11 +515,12 @@ def test_corrupt_failures_file_treated_as_empty(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(song, Path("/tmp/1.m4a"))]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        _, tracks_sent = sync_playlist(
+        _, attempted, downloaded = sync_playlist(
             spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file,
         )
 
-    assert tracks_sent == 1  # proceeded normally despite corrupt file
+    assert attempted == 1  # proceeded normally despite corrupt file
+    assert downloaded == 1
 
 
 def test_outcome_defer_logged_for_budget_limited_tracks(tmp_path: Path, caplog) -> None:

--- a/service/music_service/flows.py
+++ b/service/music_service/flows.py
@@ -69,8 +69,9 @@ def spotdl_sync_task(remove_sources: list[str]):
     try:
         result = ingest.sync_playlists(remove_sources, metrics)
         logger.info(
-            "Sync complete: %d track(s) downloaded, %d playlist(s) processed, %d pending removal(s)",
+            "Sync complete: %d of %d track(s) downloaded, %d playlist(s) processed, %d pending removal(s)",
             metrics.tracks_downloaded,
+            metrics.tracks_attempted,
             metrics.playlists_total,
             len(result.tracks),
         )


### PR DESCRIPTION
## Summary

- `sync_playlist` now returns `(removed_urls, attempted, downloaded)` instead of `(removed_urls, attempted)`. The third value is the count of tracks where `spotdl` actually returned a path — previously computed (`downloaded_urls` set) but never surfaced.
- `IngestMetrics.tracks_downloaded` now reflects actual downloads (was: attempts). Added `tracks_attempted` for the previous semantics and a matching `music_ingest_tracks_attempted_total` gauge.
- Prefect fetch log becomes `"Sync complete: X of Y track(s) downloaded, …"` so `0/4` is visibly distinct from `4/4`.
- Per-attempt budget decrement unchanged — a stuck `[MISS]` cluster would otherwise loop forever.

## Why

Last night's fetch logged `Sync complete: 4 track(s) downloaded` but scan never ran. The fetch flow doesn't trigger scan directly; the watchdog observer on `/root/Music/inbox` does, on real file creation. Since nothing actually landed on disk, scan stayed idle and there was no signal in logs or metrics that the night was a 0-download night. Full diagnosis in #124.

## Test plan

- [x] Updated `test_sync_playlist_failed_downloads_not_persisted` to assert `attempted == 4, downloaded == 2` — the exact regression for this bug.
- [x] Updated `test_miss_track_past_backoff_is_retried` to assert `downloaded == 0` when spotdl returns `path=None`.
- [x] Added `test_ingest_metrics_tracks_attempted_distinct_from_downloaded` covering the gauge pair.
- [x] `just test` equivalent (`docker build --target dev` + run) — 242 passed.

## Follow-ups (separate)

- Add a PrometheusRule in the homelab repo alerting on `music_ingest_tracks_attempted_total > 0 AND music_ingest_tracks_downloaded_total == 0` for a completed run. That's the only way a 0/N night will become visible without manually grepping logs.

Closes #124