### PR TITLE
chore(deps): bump spotdl from 4.4.4 to 4.5.0

### DIFF
--- a/fetch/music_fetch/spotdl_ops.py
+++ b/fetch/music_fetch/spotdl_ops.py
@@ -89,6 +89,7 @@ def _make_spotdl(settings: dict):
     _spotdl_instance = Spotdl(
         client_id=client_id,
         client_secret=client_secret,
+        use_official_api=True,
         downloader_settings=settings,
     )
     return _spotdl_instance

--- a/fetch/requirements.txt
+++ b/fetch/requirements.txt
@@ -1,3 +1,3 @@
-spotdl==4.4.4
+spotdl==4.5.0
 requests>=2.34.2
 yt-dlp[default]


### PR DESCRIPTION
Supersedes #121.

## Changes

- `fetch/requirements.txt`: bump `spotdl==4.4.4` → `spotdl==4.5.0`
- `fetch/music_fetch/spotdl_ops.py`: add `use_official_api=True` to the `Spotdl` constructor

## Why `use_official_api=True` is required

spotdl 4.5.0 adds `use_official_api: bool = False` to the `Spotdl` constructor. Without it, spotdl silently falls back to SpotipyFree (a no-auth scraper) even when `client_id` and `client_secret` are provided. SpotipyFree has reduced reliability for playlist lookups and does not use our Spotify credentials at all.

## Other 4.5.0 changes assessed

| Change | Impact |
|---|---|
| SpotipyFree as default | Mitigated by `use_official_api=True` |
| Fallback URL search (`search_all`) removed | More tracks will hit [MISS]/backoff rather than exhausting alternative YouTube candidates first. Logic in `spotdl_ops.py` is correct — `(song, None)` is still returned on failure, never raised. |
| Deno recommendation | Covered — we already install `nodejs` in the Dockerfile and pass `--js-runtimes node` to yt-dlp |
| YouTube provider: pytube → yt-dlp | No impact — we use `youtube-music` |
| Docker non-root user | Not relevant — we build our own image |

## Test plan

- [x] `just test` — 242 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)