### PR TITLE
feat: log missed/failed tracks, config playlist order, pipeline concurrency lock

### DIFF
--- a/fetch/music_fetch/ingest.py
+++ b/fetch/music_fetch/ingest.py
@@ -225,6 +225,13 @@ def sync_playlists(
         logger.info("Soft timeout: %ds — will stop before Kubernetes deadline fires", soft_timeout)
 
     spotdl_files = sorted(SPOTDL_DIR.glob("*.spotdl"))
+    if CONF_PATH.exists():
+        try:
+            config_order = {pl.name: i for i, pl in enumerate(load_playlists(CONF_PATH))}
+            spotdl_files.sort(key=lambda f: (config_order.get(f.stem, len(config_order)), f.stem))
+        except Exception:
+            pass  # keep alphabetical order on parse failure
+
     if not spotdl_files:
         logger.info("No .spotdl files found in %s", SPOTDL_DIR)
 
@@ -276,7 +283,7 @@ def sync_playlists(
         output_dir.mkdir(parents=True, exist_ok=True)
 
         try:
-            removed_urls, attempted, downloaded = sync_playlist(
+            removed_urls, attempted, downloaded, missed, failed = sync_playlist(
                 spotdl_file=spotdl_file,
                 output_dir=output_dir,
                 cookie_file=COOKIE_FILE,
@@ -296,6 +303,8 @@ def sync_playlists(
 
         metrics.tracks_attempted += attempted
         metrics.tracks_downloaded += downloaded
+        metrics.tracks_missed += missed
+        metrics.tracks_failed += failed
         if remaining is not None:
             # Budget is consumed per attempt: a stuck [MISS] cluster would otherwise loop forever.
             remaining -= attempted

--- a/fetch/music_fetch/metrics.py
+++ b/fetch/music_fetch/metrics.py
@@ -40,6 +40,8 @@ class IngestMetrics:
     playlists_deferred: int = 0
     tracks_attempted: int = 0
     tracks_downloaded: int = 0
+    tracks_missed: int = 0
+    tracks_failed: int = 0
     cookies_expired: bool = False
     failure_reason: str = ""
 
@@ -52,6 +54,8 @@ class IngestMetrics:
             _gauge("music_ingest_playlists_deferred_total", self.playlists_deferred),
             _gauge("music_ingest_tracks_attempted_total", self.tracks_attempted),
             _gauge("music_ingest_tracks_downloaded_total", self.tracks_downloaded),
+            _gauge("music_ingest_tracks_missed_total", self.tracks_missed),
+            _gauge("music_ingest_tracks_failed_total", self.tracks_failed),
             _gauge("music_ingest_cookies_expired", int(self.cookies_expired)),
         ]
         if not self.success and self.failure_reason:

--- a/fetch/music_fetch/spotdl_ops.py
+++ b/fetch/music_fetch/spotdl_ops.py
@@ -124,7 +124,7 @@ def sync_playlist(
     cookie_file: Path,
     track_limit: int | None = None,
     failures_file: Path | None = None,
-) -> tuple[set[str], int, int]:
+) -> tuple[set[str], int, int, int, int]:
     """Sync a playlist from its .spotdl file.
 
     Downloads tracks new to the Spotify playlist, up to *track_limit* new
@@ -140,6 +140,8 @@ def sync_playlist(
       - the number of tracks sent to spotdl this session (tracks *attempted*; budget
         is consumed per attempt so a stuck [MISS] doesn't loop forever)
       - the number of tracks spotdl actually wrote to disk (path is not None)
+      - the number of tracks with no YouTube source found ([MISS])
+      - the number of tracks where a source was found but the download failed ([FAIL])
 
     Note on ordering: when *track_limit* is set, the batch is taken from the front of
     the list returned by spotdl.search(), which for Spotify playlists is typically
@@ -218,13 +220,16 @@ def sync_playlist(
     # Log per-track outcomes.
     # MISS vs FAIL: if song.download_url is None, spotdl found no YouTube source (LookupError);
     # if it's set, a source was found but the download itself failed (AudioProviderError).
+    n_missed = n_failed = 0
     for song, path in results:
         if path is not None:
             logger.info("[OK]   %s", _song_label(song))
             failures.pop(song.url, None)
         elif getattr(song, "download_url", None):
+            n_failed += 1
             logger.info("[FAIL] %s → download failed", _song_label(song))
         else:
+            n_missed += 1
             entry = failures.get(song.url, {"attempts": 0})
             attempts = entry["attempts"] + 1
             days = _backoff_days(attempts)
@@ -253,7 +258,7 @@ def sync_playlist(
             ensure_ascii=False,
         )
 
-    return removed_urls, len(truly_new), len(downloaded_urls)
+    return removed_urls, len(truly_new), len(downloaded_urls), n_missed, n_failed
 
 
 def find_track_in_snapshot(snapshot: list[dict], url: str) -> dict | None:

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -329,6 +329,7 @@ def test_run_returns_pending_removals_with_remove_sources(tmp_path: Path) -> Non
 
     with mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
          mock.patch.object(ingest, "COOKIE_FILE", cookie_file), \
+         mock.patch.object(ingest, "CONF_PATH", tmp_path / "missing.conf"), \
          mock.patch.dict("os.environ", {"SPOTIFY_CLIENT_ID": "id", "SPOTIFY_CLIENT_SECRET": "secret"}), \
          mock.patch("shutil.disk_usage", return_value=mock.Mock(free=10 * 1024**3)), \
          mock.patch("music_fetch.ingest.reconcile_playlists", return_value=["gone-playlist"]), \

--- a/fetch/tests/test_ingest.py
+++ b/fetch/tests/test_ingest.py
@@ -202,6 +202,57 @@ def test_budget_spans_playlists() -> None:
 
 
 # ---------------------------------------------------------------------------
+# sync_playlists — config ordering
+# ---------------------------------------------------------------------------
+
+
+def test_sync_playlists_processes_in_config_order(tmp_path: Path) -> None:
+    """Playlists are synced in playlists.conf order, not alphabetically.
+
+    Regression: previously sorted(glob("*.spotdl")) produced alphabetical
+    order, so 'later' was processed before 'wedding' even though 'wedding'
+    was listed first in the config.
+    """
+    import unittest.mock as mock
+    from music_fetch import ingest
+    from music_fetch.metrics import IngestMetrics
+
+    spotdl_dir = tmp_path / "spotdl"
+    spotdl_dir.mkdir()
+
+    # Config order: aaaaaaah, wedding, later
+    conf = tmp_path / "playlists.conf"
+    conf.write_text(
+        "aaaaaaah  https://open.spotify.com/playlist/A\n"
+        "wedding   https://open.spotify.com/playlist/W\n"
+        "later     https://open.spotify.com/playlist/L\n",
+        encoding="utf-8",
+    )
+
+    # Alphabetical order would be: aaaaaaah, later, wedding
+    for name in ("aaaaaaah", "later", "wedding"):
+        (spotdl_dir / f"{name}.spotdl").write_text(
+            '{"type":"sync","query":["https://open.spotify.com/playlist/X"],"songs":[]}',
+            encoding="utf-8",
+        )
+
+    processed: list[str] = []
+
+    def fake_sync(spotdl_file, **_kwargs):
+        processed.append(spotdl_file.stem)
+        return set(), 0, 0, 0, 0
+
+    with mock.patch.object(ingest, "SPOTDL_DIR", spotdl_dir), \
+         mock.patch.object(ingest, "CONF_PATH", conf), \
+         mock.patch.object(ingest, "COOKIE_FILE", tmp_path / "cookies.txt"), \
+         mock.patch.object(ingest, "FAILURES_FILE", tmp_path / ".failures.json"), \
+         mock.patch("music_fetch.ingest.sync_playlist", side_effect=fake_sync):
+        ingest.sync_playlists([], IngestMetrics())
+
+    assert processed == ["aaaaaaah", "wedding", "later"]
+
+
+# ---------------------------------------------------------------------------
 # _collect_removals
 # ---------------------------------------------------------------------------
 
@@ -306,6 +357,8 @@ def test_run_reconcile_failure_sets_reconcile_error_reason(tmp_path: Path) -> No
             self.failure_reason = ""
             self.tracks_attempted = 0
             self.tracks_downloaded = 0
+            self.tracks_missed = 0
+            self.tracks_failed = 0
             self.playlists_total = 0
             self.playlists_skipped = 0
             self.playlists_deferred = 0

--- a/fetch/tests/test_spotdl_ops.py
+++ b/fetch/tests/test_spotdl_ops.py
@@ -75,7 +75,7 @@ def test_sync_playlist_after_stub_downloads_all_songs(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(s, Path(f"/tmp/{i}.m4a")) for i, s in enumerate(songs)]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, attempted, downloaded = sync_playlist(
+        removed_urls, attempted, downloaded, _missed, _failed = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
@@ -121,7 +121,7 @@ def test_sync_playlist_second_run_skips_known_songs(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(s, Path(f"/tmp/{i}.m4a")) for i, s in enumerate(new_only)]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, attempted, downloaded = sync_playlist(
+        removed_urls, attempted, downloaded, _missed, _failed = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
@@ -168,7 +168,7 @@ def test_sync_playlist_detects_removed_tracks(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = []  # nothing new to download
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, attempted, downloaded = sync_playlist(
+        removed_urls, attempted, downloaded, _missed, _failed = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
@@ -204,7 +204,7 @@ def test_sync_playlist_failed_downloads_not_persisted(tmp_path: Path) -> None:
     ]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        removed_urls, attempted, downloaded = sync_playlist(
+        removed_urls, attempted, downloaded, n_missed, n_failed = sync_playlist(
             spotdl_file=spotdl_file,
             output_dir=output_dir,
             cookie_file=cookie_file,
@@ -212,6 +212,8 @@ def test_sync_playlist_failed_downloads_not_persisted(tmp_path: Path) -> None:
 
     assert attempted == 4  # all 4 were sent to spotdl
     assert downloaded == 2  # only 2 actually landed on disk (regression for issue #124)
+    assert n_missed == 2
+    assert n_failed == 0
     assert removed_urls == set()
 
     # Only the 2 successful downloads should be in the snapshot
@@ -391,7 +393,7 @@ def test_miss_track_in_backoff_is_skipped(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(fresh, Path("/tmp/fresh.m4a"))]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        _, attempted, downloaded = sync_playlist(
+        _, attempted, downloaded, _missed, _failed = sync_playlist(
             spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file,
             failures_file=failures_file, track_limit=10,
         )
@@ -424,7 +426,7 @@ def test_miss_track_past_backoff_is_retried(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(song, None)]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        _, attempted, downloaded = sync_playlist(
+        _, attempted, downloaded, _missed, _failed = sync_playlist(
             spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file,
         )
 
@@ -515,7 +517,7 @@ def test_corrupt_failures_file_treated_as_empty(tmp_path: Path) -> None:
     mock_spotdl.download_songs.return_value = [(song, Path("/tmp/1.m4a"))]
 
     with mock.patch("music_fetch.spotdl_ops._make_spotdl", return_value=mock_spotdl):
-        _, attempted, downloaded = sync_playlist(
+        _, attempted, downloaded, _missed, _failed = sync_playlist(
             spotdl_file=spotdl_file, output_dir=output_dir, cookie_file=cookie_file, failures_file=failures_file,
         )
 

--- a/service/music_service/flows.py
+++ b/service/music_service/flows.py
@@ -68,10 +68,21 @@ def spotdl_sync_task(remove_sources: list[str]):
     start = time.monotonic()
     try:
         result = ingest.sync_playlists(remove_sources, metrics)
+        not_downloaded = metrics.tracks_attempted - metrics.tracks_downloaded
+        suffix = ""
+        if not_downloaded:
+            parts = []
+            if metrics.tracks_missed:
+                parts.append(f"{metrics.tracks_missed} no source")
+            if metrics.tracks_failed:
+                parts.append(f"{metrics.tracks_failed} download error")
+            if parts:
+                suffix = f" ({', '.join(parts)})"
         logger.info(
-            "Sync complete: %d of %d track(s) downloaded, %d playlist(s) processed, %d pending removal(s)",
+            "Sync complete: %d of %d track(s) downloaded%s, %d playlist(s) processed, %d pending removal(s)",
             metrics.tracks_downloaded,
             metrics.tracks_attempted,
+            suffix,
             metrics.playlists_total,
             len(result.tracks),
         )
@@ -213,20 +224,26 @@ def reconcile_task() -> None:
 @flow(name="fetch", log_prints=True)
 def fetch_and_scan_flow() -> None:
     """Fetch only: spotdl sync. Scan is triggered separately by the file watcher."""
-    preflight_task()
-    remove_sources = reconcile_playlists_task()
-    pending = spotdl_sync_task(remove_sources)
-    save_removals_task(pending)
+    with concurrency("pipeline", occupy=1):
+        preflight_task()
+        remove_sources = reconcile_playlists_task()
+        pending = spotdl_sync_task(remove_sources)
+        save_removals_task(pending)
 
 
 @flow(name="scan", log_prints=True)
 def scan_flow() -> None:
     """Scan: apply any pending removals, import inbox, regenerate playlists."""
-    apply_removals_task()
-    beet_import_task()
-    quarantine_task()
-    asis_import_task()
-    beet_update_task()
-    regen_playlists_task()
-    navidrome_task()
-    reconcile_task()
+    logger = get_run_logger()
+    try:
+        with concurrency("pipeline", occupy=1, timeout_seconds=0):
+            apply_removals_task()
+            beet_import_task()
+            quarantine_task()
+            asis_import_task()
+            beet_update_task()
+            regen_playlists_task()
+            navidrome_task()
+            reconcile_task()
+    except TimeoutError:
+        logger.info("Scan skipped — pipeline busy (fetch or scan already running)")

--- a/service/music_service/prefect_client.py
+++ b/service/music_service/prefect_client.py
@@ -122,6 +122,10 @@ async def _upsert_limits() -> None:
             name="beet-import",
             limit=1,
         )
+        await client.upsert_global_concurrency_limit_by_name(
+            name="pipeline",
+            limit=1,
+        )
 
 
 def ensure_concurrency_limits() -> None:
@@ -134,6 +138,6 @@ def ensure_concurrency_limits() -> None:
         return
     try:
         asyncio.run(_upsert_limits())
-        logger.info("Prefect concurrency limit 'beet-import' ensured (limit=1)")
+        logger.info("Prefect concurrency limits ensured: beet-import=1, pipeline=1")
     except Exception as exc:
         logger.warning("Could not upsert Prefect concurrency limit: %s", exc)

--- a/service/tests/test_flows.py
+++ b/service/tests/test_flows.py
@@ -173,7 +173,10 @@ def test_fetch_flow_runs_fetch_steps_only():
 
     with patch("music_service.flows.ingest") as mock_ingest, \
          patch("music_service.flows.scan") as mock_scan, \
-         patch("music_service.flows.IngestMetrics", return_value=mock_metrics):
+         patch("music_service.flows.IngestMetrics", return_value=mock_metrics), \
+         patch("music_service.flows.concurrency") as mock_concurrency:
+        mock_concurrency.return_value.__enter__.return_value = None
+        mock_concurrency.return_value.__exit__.return_value = False
         mock_ingest.preflight.side_effect = lambda: call_order.append("preflight")
         mock_ingest.reconcile_playlists.side_effect = lambda: (call_order.append("reconcile-playlists"), [])[1]
         mock_ingest.sync_playlists.side_effect = lambda *_: (call_order.append("spotdl-sync"), mock_pending)[1]
@@ -218,3 +221,14 @@ def test_scan_flow_runs_all_scan_steps_in_order():
     ]
     mock_ingest.preflight.assert_not_called()
     mock_ingest.sync_playlists.assert_not_called()
+
+
+def test_scan_flow_skips_when_pipeline_busy():
+    """Scan exits immediately if the pipeline concurrency slot is taken."""
+    from music_service.flows import scan_flow
+    with patch("music_service.flows.concurrency") as mock_concurrency, \
+         patch("music_service.flows.ingest") as mock_ingest:
+        mock_concurrency.return_value.__enter__.side_effect = TimeoutError
+        mock_concurrency.return_value.__exit__.return_value = False
+        scan_flow()
+        mock_ingest.load_and_clear_pending_removals.assert_not_called()


### PR DESCRIPTION
## Summary

Three improvements surfaced from analysing last night's run logs:

- **MISS/FAIL breakdown in sync log** — `sync_playlist` now counts tracks that returned no YouTube source (`[MISS]`) vs tracks where a source was found but the download failed (`[FAIL]`). These are accumulated in `IngestMetrics` (and pushed to Prometheus) and appended to the summary log line when nonzero: `21 of 25 track(s) downloaded (3 no source, 1 download error)`.

- **Config-order playlist sync** — playlists were previously processed in alphabetical `.spotdl` filename order, so `later` (l) was always synced before `wedding` (w) regardless of their position in `playlists.conf`. Sync now follows config order; playlists absent from the config (orphans being cleaned up) sort to the end alphabetically.

- **Pipeline concurrency lock via Prefect** — a `pipeline` global concurrency limit (limit=1) prevents fetch and scan from running concurrently. `fetch_and_scan_flow` acquires the slot blocking (the cron job always runs). `scan_flow` uses `timeout_seconds=0` and logs `"Scan skipped — pipeline busy"` if the slot is taken. The limit is registered at startup alongside `beet-import`. This replaces the watchdog-triggered double-scan seen in last night's logs.

## Test plan

- [ ] `just test` passes
- [ ] After deploy, verify next fetch log shows playlists in config order (aaaaaaah → wedding → mood → later)
- [ ] Trigger a manual scan while fetch is running; confirm "Scan skipped — pipeline busy" appears in scan flow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)