### PR TITLE
fix(service): scan after fetch; fix justfile parse error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 cookies.txt
 *.spotdl
 
+# Claude Code runtime files
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
 # Docker build artifacts
 .dockerenv
 

--- a/justfile
+++ b/justfile
@@ -68,9 +68,7 @@ mb-fingerprint:
 # One-time migration (issue #117): copy source= → sources= for all beets items.
 # IMPORTANT: deploy new code first, then run this. Safe to re-run.
 migrate-sources:
-    kubectl exec -n music $(kubectl get pods -n music -l app=music-pipeline -o jsonpath='{.items[0].metadata.name}') -- python3 -c "
-from beets.library import Library; lib = Library('/root/.config/beets/library.db', '/root/Music/library'); items = list(lib.items('source:')); print(f'Migrating {len(items)} items'); [item.__setitem__('sources', item.get('source') or '') or item.__setitem__('source', '') or item.store() for item in items]; lib._close(); print('Migration complete.')
-"
+    kubectl exec -n music $(kubectl get pods -n music -l app=music-pipeline -o jsonpath='{.items[0].metadata.name}') -- python3 -c "from beets.library import Library; lib = Library('/root/.config/beets/library.db', '/root/Music/library'); items = list(lib.items('source:')); print(f'Migrating {len(items)} items'); [item.__setitem__('sources', item.get('source') or '') or item.__setitem__('source', '') or item.store() for item in items]; lib._close(); print('Migration complete.')"
 
 # Dump beets DB and export JSON from the container
 backup:

--- a/service/music_service/flows.py
+++ b/service/music_service/flows.py
@@ -223,12 +223,13 @@ def reconcile_task() -> None:
 
 @flow(name="fetch", log_prints=True)
 def fetch_and_scan_flow() -> None:
-    """Fetch only: spotdl sync. Scan is triggered separately by the file watcher."""
+    """Fetch: spotdl sync, then scan inbox."""
     with concurrency("pipeline", occupy=1):
         preflight_task()
         remove_sources = reconcile_playlists_task()
         pending = spotdl_sync_task(remove_sources)
         save_removals_task(pending)
+    scan_flow()
 
 
 @flow(name="scan", log_prints=True)

--- a/service/tests/test_flows.py
+++ b/service/tests/test_flows.py
@@ -163,7 +163,7 @@ def test_reconcile_task_calls_reconcile_all():
 # ---------------------------------------------------------------------------
 
 
-def test_fetch_flow_runs_fetch_steps_only():
+def test_fetch_flow_runs_fetch_then_scan():
     from music_service.flows import fetch_and_scan_flow
     call_order: list[str] = []
     mock_pending = MagicMock()
@@ -173,18 +173,25 @@ def test_fetch_flow_runs_fetch_steps_only():
 
     with patch("music_service.flows.ingest") as mock_ingest, \
          patch("music_service.flows.scan") as mock_scan, \
+         patch("music_service.flows.reconcile") as mock_reconcile, \
          patch("music_service.flows.IngestMetrics", return_value=mock_metrics), \
-         patch("music_service.flows.concurrency") as mock_concurrency:
+         patch("music_service.flows.concurrency") as mock_concurrency, \
+         patch("music_scan.process.run_beet_update"), \
+         patch("music_scan.navidrome.trigger_scan"):
         mock_concurrency.return_value.__enter__.return_value = None
         mock_concurrency.return_value.__exit__.return_value = False
         mock_ingest.preflight.side_effect = lambda: call_order.append("preflight")
         mock_ingest.reconcile_playlists.side_effect = lambda: (call_order.append("reconcile-playlists"), [])[1]
         mock_ingest.sync_playlists.side_effect = lambda *_: (call_order.append("spotdl-sync"), mock_pending)[1]
+        mock_ingest.load_and_clear_pending_removals.return_value = None
+        mock_scan.run_inbox_import.side_effect = lambda: (call_order.append("beet-import"), [])[1]
+        mock_reconcile.reconcile_all.return_value = 0
 
         fetch_and_scan_flow()
 
-    assert call_order == ["preflight", "reconcile-playlists", "spotdl-sync"]
-    mock_scan.run_inbox_import.assert_not_called()
+    assert call_order[:3] == ["preflight", "reconcile-playlists", "spotdl-sync"]
+    assert "beet-import" in call_order
+    mock_scan.run_inbox_import.assert_called_once()
 
 
 def test_scan_flow_runs_all_scan_steps_in_order():


### PR DESCRIPTION
## Summary

- **Scan stuck in inbox**: `fetch_and_scan_flow` now calls `scan_flow()` as a subflow after releasing the pipeline concurrency lock. Previously, if the file watcher fired while fetch was running, `scan_flow` timed out immediately (`timeout_seconds=0`) and was never retried — leaving downloaded files stuck in the inbox. Matches the direct-mode behaviour where `_run_fetch_and_scan` always runs both in sequence.
- **justfile broken**: `just` 1.42.4 parses multi-line double-quoted strings in recipe bodies as expression syntax, breaking all recipes. The `migrate-sources` Python code was already a single semicolon-joined line; collapsing `python3 -c "...\n...\n"` to one line fixes it.

## Test plan

- [ ] `just test` passes (244 tests, including renamed `test_fetch_flow_runs_fetch_then_scan`)
- [ ] `just --list` lists all recipes without error
- [ ] Deploy and observe: after next scheduled fetch, scan runs automatically without needing a manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)